### PR TITLE
Add FunctionBuilder wrapper, start documenting functions + update to DuckDB v1.1.3

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,10 +22,10 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.1
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.3
     with:
-      duckdb_version: v1.1.1
-      ci_tools_version: v1.1.1
+      duckdb_version: v1.1.3
+      ci_tools_version: v1.1.3
       extension_name: geography
 
   duckdb-stable-deploy:
@@ -34,6 +34,6 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.1.1
+      duckdb_version: v1.1.3
       extension_name: geography
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ include_directories(src/include)
 
 set(EXTENSION_SOURCES
     src/geography_extension.cpp
+    src/function_builder.cpp
     src/s2_dependencies.cpp
     src/s2_types.cpp
     src/s2_cell_ops.cpp

--- a/src/function_builder.cpp
+++ b/src/function_builder.cpp
@@ -1,0 +1,42 @@
+#include "function_builder.hpp"
+#include "duckdb/catalog/catalog_entry/function_entry.hpp"
+#include "duckdb/main/extension_util.hpp"
+
+namespace duckdb {
+
+void FunctionBuilder::Register(DatabaseInstance& db, const char* name,
+                               ScalarFunctionBuilder& builder) {
+  // Register the function
+  ExtensionUtil::RegisterFunction(db, std::move(builder.set));
+
+  // Also add the parameter names. We need to access the catalog entry for this.
+  auto& catalog = Catalog::GetSystemCatalog(db);
+  auto transaction = CatalogTransaction::GetSystemTransaction(db);
+  auto& schema = catalog.GetSchema(transaction, DEFAULT_SCHEMA);
+  auto catalog_entry =
+      schema.GetEntry(transaction, CatalogType::SCALAR_FUNCTION_ENTRY, name);
+  if (!catalog_entry) {
+    // This should not happen, we just registered the function
+    throw InternalException(
+        "Function with name \"%s\" not found in FunctionBuilder::AddScalar", name);
+  }
+
+  auto& func_entry = catalog_entry->Cast<FunctionEntry>();
+  if (!builder.parameter_names.empty()) {
+    func_entry.parameter_names = std::move(builder.parameter_names);
+  }
+
+  if (!builder.description.empty()) {
+    func_entry.description = std::move(builder.description);
+  }
+
+  if (!builder.example.empty()) {
+    func_entry.example = std::move(builder.example);
+  }
+
+  if (!builder.tags.empty()) {
+    func_entry.tags = std::move(builder.tags);
+  }
+}
+
+}  // namespace duckdb

--- a/src/include/function_builder.hpp
+++ b/src/include/function_builder.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+//------------------------------------------------------------------------------
+// Scalar Function Variant Builder
+//------------------------------------------------------------------------------
+
+class ScalarFunctionVariantBuilder {
+  friend class ScalarFunctionBuilder;
+
+ public:
+  void AddParameter(const char* name, LogicalType type);
+  void SetReturnType(LogicalType type);
+  void SetFunction(scalar_function_t fn);
+
+ private:
+  explicit ScalarFunctionVariantBuilder()
+      : function({}, LogicalTypeId::INVALID, nullptr) {}
+
+  ScalarFunction function;
+
+  vector<string> parameter_names = {};
+};
+
+inline void ScalarFunctionVariantBuilder::AddParameter(const char* name,
+                                                       LogicalType type) {
+  function.arguments.emplace_back(std::move(type));
+  parameter_names.emplace_back(name);
+}
+
+inline void ScalarFunctionVariantBuilder::SetReturnType(LogicalType type) {
+  function.return_type = std::move(type);
+}
+
+inline void ScalarFunctionVariantBuilder::SetFunction(scalar_function_t fn) {
+  function.function = fn;
+}
+
+//------------------------------------------------------------------------------
+// Scalar Function Builder
+//------------------------------------------------------------------------------
+
+class ScalarFunctionBuilder {
+  friend class FunctionBuilder;
+
+ public:
+  template <class CALLBACK>
+  void AddVariant(CALLBACK&& callback);
+  void SetDescription(const string& desc);
+  void SetExample(const string& ex);
+  void SetTag(const string& key, const string& value);
+
+ private:
+  explicit ScalarFunctionBuilder(const char* name) : set(name) {}
+
+  ScalarFunctionSet set;
+
+  vector<string> parameter_names;
+  string description;
+  string example;
+  unordered_map<string, string> tags = {};
+};
+
+inline void ScalarFunctionBuilder::SetDescription(const string& desc) {
+  description = desc;
+}
+
+inline void ScalarFunctionBuilder::SetExample(const string& ex) { example = ex; }
+
+inline void ScalarFunctionBuilder::SetTag(const string& key, const string& value) {
+  tags[key] = value;
+}
+
+template <class CALLBACK>
+void ScalarFunctionBuilder::AddVariant(CALLBACK&& callback) {
+  ScalarFunctionVariantBuilder builder;
+
+  callback(builder);
+
+  // A return type is required
+  if (builder.function.return_type.id() == LogicalTypeId::INVALID) {
+    throw InternalException("Return type not set in ScalarFunctionBuilder::AddVariant");
+  }
+
+  // Add the new variant to the set
+  set.AddFunction(std::move(builder.function));
+
+  // DuckDB does not support naming individual parameters differently between overloads,
+  // there is only a single list of parameter names for the entire function.
+  // Therefore, our only option right now is to append the new parameter names to the
+  // list. This is going to change in DuckDB 1.2 where overloads will be able to have
+  // different parameter names.
+
+  // Add any new parameter names to the list
+  const auto& old_params = parameter_names;
+  const auto& new_params = builder.parameter_names;
+
+  for (idx_t offset = old_params.size(); offset < new_params.size(); offset++) {
+    parameter_names.emplace_back(builder.parameter_names[offset]);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Function Builder
+//------------------------------------------------------------------------------
+
+class FunctionBuilder {
+ public:
+  template <class CALLBACK>
+  static void RegisterScalar(DatabaseInstance& db, const char* name, CALLBACK&& callback);
+
+ private:
+  static void Register(DatabaseInstance& db, const char* name,
+                       ScalarFunctionBuilder& builder);
+};
+
+template <class CALLBACK>
+void FunctionBuilder::RegisterScalar(DatabaseInstance& db, const char* name,
+                                     CALLBACK&& callback) {
+  ScalarFunctionBuilder builder(name);
+  callback(builder);
+
+  Register(db, name, builder);
+}
+
+}  // namespace duckdb

--- a/src/s2_accessors.cpp
+++ b/src/s2_accessors.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_util.hpp"
 
+#include "function_builder.hpp"
+
 #include "s2/s2earth.h"
 #include "s2geography/accessors.h"
 
@@ -17,9 +19,20 @@ namespace {
 
 struct S2IsEmpty {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_isempty", {Types::GEOGRAPHY()}, LogicalType::BOOLEAN,
-                             ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_isempty", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BOOLEAN);
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Returns true if the geography is empty.");
+          func.SetExample("SELECT s2_isempty('POINT(0 0)') AS is_empty;");
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "accessors");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -38,9 +51,18 @@ struct S2IsEmpty {
 
 struct S2Area {
   static void Register(DatabaseInstance& instance) {
-    auto fn =
-        ScalarFunction("s2_area", {Types::GEOGRAPHY()}, LogicalType::DOUBLE, ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, "s2_area", [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("geog", Types::GEOGRAPHY());
+        variant.SetReturnType(LogicalType::DOUBLE);
+        variant.SetFunction(ExecuteFn);
+      });
+
+      func.SetDescription("Returns the area of the geography.");
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "accessors");
+    });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -75,9 +97,19 @@ struct S2Area {
 
 struct S2Perimieter {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_perimeter", {Types::GEOGRAPHY()}, LogicalType::DOUBLE,
-                             ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_perimeter", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::DOUBLE);
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Returns the perimeter of the geography.");
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "accessors");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -110,9 +142,19 @@ struct S2Perimieter {
 
 struct S2Length {
   static void Register(DatabaseInstance& instance) {
-    auto fn =
-        ScalarFunction("s2_length", {Types::GEOGRAPHY()}, LogicalType::DOUBLE, ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_length", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::DOUBLE);
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Returns the length of the geography.");
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "accessors");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -146,13 +188,31 @@ struct S2Length {
 
 struct S2XY {
   static void Register(DatabaseInstance& instance) {
-    auto fn_x =
-        ScalarFunction("s2_x", {Types::GEOGRAPHY()}, LogicalType::DOUBLE, ExecuteFnX);
-    ExtensionUtil::RegisterFunction(instance, fn_x);
+    FunctionBuilder::RegisterScalar(instance, "s2_x", [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("geog", Types::GEOGRAPHY());
+        variant.SetReturnType(LogicalType::DOUBLE);
+        variant.SetFunction(ExecuteFnX);
+      });
 
-    auto fn_y =
-        ScalarFunction("s2_y", {Types::GEOGRAPHY()}, LogicalType::DOUBLE, ExecuteFnY);
-    ExtensionUtil::RegisterFunction(instance, fn_y);
+      func.SetDescription("Returns the x coordinate of the geography.");
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "accessors");
+    });
+
+    FunctionBuilder::RegisterScalar(instance, "s2_y", [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("geog", Types::GEOGRAPHY());
+        variant.SetReturnType(LogicalType::DOUBLE);
+        variant.SetFunction(ExecuteFnY);
+      });
+
+      func.SetDescription("Returns the y coordinate of the geography.");
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "accessors");
+    });
   }
 
   static inline void ExecuteFnX(DataChunk& args, ExpressionState& state, Vector& result) {

--- a/src/s2_binary_index_ops.cpp
+++ b/src/s2_binary_index_ops.cpp
@@ -8,6 +8,7 @@
 
 #include "s2geography/build.h"
 
+#include "function_builder.hpp"
 #include "global_options.hpp"
 
 namespace duckdb {
@@ -18,38 +19,117 @@ namespace {
 
 struct S2BinaryIndexOp {
   static void Register(DatabaseInstance& instance) {
-    auto mayintersect =
-        ScalarFunction("s2_mayintersect", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                       LogicalType::BOOLEAN, ExecuteMayIntersectFn);
-    ExtensionUtil::RegisterFunction(instance, mayintersect);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_mayintersect", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BOOLEAN);
+            variant.SetFunction(ExecuteMayIntersectFn);
+          });
 
-    auto intersects =
-        ScalarFunction("s2_intersects", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                       LogicalType::BOOLEAN, ExecuteIntersectsFn);
-    ExtensionUtil::RegisterFunction(instance, intersects);
+          func.SetDescription("Returns true if the two geographies may intersect.");
+          // TODO: Example
 
-    auto contains =
-        ScalarFunction("s2_contains", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                       LogicalType::BOOLEAN, ExecuteContainsFn);
-    ExtensionUtil::RegisterFunction(instance, contains);
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "predicate");
+        });
 
-    auto equals = ScalarFunction("s2_equals", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                                 LogicalType::BOOLEAN, ExecuteEqualsFn);
-    ExtensionUtil::RegisterFunction(instance, equals);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_intersects", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BOOLEAN);
+            variant.SetFunction(ExecuteIntersectsFn);
+          });
 
-    auto intersection =
-        ScalarFunction("s2_intersection", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                       Types::GEOGRAPHY(), ExecuteIntersectionFn);
-    ExtensionUtil::RegisterFunction(instance, intersection);
+          func.SetDescription("Returns true if the two geographies intersect.");
+          // TODO: Example
 
-    auto difference =
-        ScalarFunction("s2_difference", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                       Types::GEOGRAPHY(), ExecuteDifferenceFn);
-    ExtensionUtil::RegisterFunction(instance, difference);
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "predicate");
+        });
 
-    auto union_ = ScalarFunction("s2_union", {Types::GEOGRAPHY(), Types::GEOGRAPHY()},
-                                 Types::GEOGRAPHY(), ExecuteUnionFn);
-    ExtensionUtil::RegisterFunction(instance, union_);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_contains", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BOOLEAN);
+            variant.SetFunction(ExecuteContainsFn);
+          });
+
+          func.SetDescription("Returns true if the first geography contains the second.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "predicate");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_equals", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BOOLEAN);
+            variant.SetFunction(ExecuteEqualsFn);
+          });
+
+          func.SetDescription("Returns true if the two geographies are equal.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "predicate");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_intersection", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteIntersectionFn);
+          });
+
+          func.SetDescription("Returns the intersection of two geographies.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "overlay");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_difference", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteDifferenceFn);
+          });
+
+          func.SetDescription("Returns the difference of two geographies.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "overlay");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_union", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog1", Types::GEOGRAPHY());
+            variant.AddParameter("geog2", Types::GEOGRAPHY());
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteUnionFn);
+          });
+
+          func.SetDescription("Returns the union of two geographies.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "overlay");
+        });
   }
 
   using UniqueGeography = std::unique_ptr<s2geography::Geography>;

--- a/src/s2_data.cpp
+++ b/src/s2_data.cpp
@@ -4,12 +4,13 @@
 #include "duckdb/main/extension_util.hpp"
 
 #include <absl/base/config.h>
-#include <openssl/opensslv.h>
 #include <s2geography.h>
 
 #include "s2_data_static.hpp"
 #include "s2_geography_serde.hpp"
 #include "s2_types.hpp"
+
+#include "function_builder.hpp"
 
 namespace duckdb {
 
@@ -143,9 +144,19 @@ const std::vector<City>& ItemList() {
 template <typename T>
 struct S2DataScalar {
   static void Register(DatabaseInstance& instance, const char* fn_name) {
-    auto fn =
-        ScalarFunction(fn_name, {LogicalType::VARCHAR}, Types::GEOGRAPHY(), ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, fn_name, [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("name", LogicalType::VARCHAR);
+        variant.SetReturnType(Types::GEOGRAPHY());
+        variant.SetFunction(ExecuteFn);
+      });
+
+      // TODO: Example
+      // TODO: Description
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "data");
+    });
   }
 
   static void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {

--- a/src/s2_functions_io.cpp
+++ b/src/s2_functions_io.cpp
@@ -14,15 +14,29 @@
 #include "s2geography/wkt-reader.h"
 #include "s2geography/wkt-writer.h"
 
+#include "function_builder.hpp"
+
 namespace duckdb {
 
 namespace duckdb_s2 {
 
 struct S2GeogFromText {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_geogfromtext", {LogicalType::VARCHAR},
-                             Types::GEOGRAPHY(), ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_geogfromtext", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("wkt", LogicalType::VARCHAR);
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Returns the geography from a WKT string.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
+
     ExtensionUtil::RegisterCastFunction(instance, LogicalType::VARCHAR,
                                         Types::GEOGRAPHY(), BoundCastInfo(ExecuteCast),
                                         1);
@@ -51,14 +65,37 @@ struct S2GeogFromText {
 
 struct S2AsText {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_astext", {Types::GEOGRAPHY()}, LogicalType::VARCHAR,
-                             ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_astext", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::VARCHAR);
+            variant.SetFunction(ExecuteFn);
+          });
 
-    auto fn_format =
-        ScalarFunction("s2_format", {Types::GEOGRAPHY(), LogicalType::TINYINT},
-                       LogicalType::VARCHAR, ExecuteFnPrec);
-    ExtensionUtil::RegisterFunction(instance, fn_format);
+          func.SetDescription("Returns the WKT string of the geography.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_format", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.AddParameter("precision", LogicalType::TINYINT);
+            variant.SetReturnType(LogicalType::VARCHAR);
+            variant.SetFunction(ExecuteFnPrec);
+          });
+
+          func.SetDescription(
+              "Returns the WKT string of the geography with a given precision.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
 
     ExtensionUtil::RegisterCastFunction(instance, Types::GEOGRAPHY(),
                                         LogicalType::VARCHAR, BoundCastInfo(ExecuteCast),
@@ -107,9 +144,20 @@ struct S2AsText {
 
 struct S2GeogFromWKB {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_geogfromwkb", {LogicalType::BLOB}, Types::GEOGRAPHY(),
-                             ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_geogfromwkb", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("wkb", LogicalType::BLOB);
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Converts a WKB blob to a geography.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -130,9 +178,20 @@ struct S2GeogFromWKB {
 
 struct S2AsWKB {
   static void Register(DatabaseInstance& instance) {
-    auto fn =
-        ScalarFunction("s2_aswkb", {Types::GEOGRAPHY()}, LogicalType::BLOB, ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_aswkb", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::BLOB);
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Returns the WKB blob of the geography.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -152,9 +211,21 @@ struct S2AsWKB {
 
 struct S2GeogPrepare {
   static void Register(DatabaseInstance& instance) {
-    auto fn =
-        ScalarFunction("s2_prepare", {Types::GEOGRAPHY()}, Types::GEOGRAPHY(), ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_prepare", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription(
+              "Prepares a geography for faster predicate and overlay operations.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {


### PR DESCRIPTION
This PR adds a new `FunctionBuilder` wrapper class to help with creation and documentation of functions within the extension.

We're in general moving towards auto-generating more of our documentation when it comes to functions/types/database entries that extensions add, and the idea is to be able to use DuckDB itself as the source-of-truth by embedding descriptions/examples into the catalog. For example, running `SELECT * FROM duckdb_functions()` we can see that there are columns such as `description`, `example`, `parameter_names` and `tags`. The tags field is particularly interesting IMO as we can use it to group catalog entries with the extension they belong to or into other semantic categories. This makes it relatively easy to produce an up-to-date function reference list with a python script, [like I do in spatial](https://github.com/duckdb/duckdb_spatial/blob/main/generate_function_reference.py).

Unfortunately the API for setting these fields is not really well developed and is missing from the `ExtensionUtil`. Additionally, there are more changes on the way ([see e.g.](https://github.com/duckdb/duckdb/pull/14838)). I've thus introduced a new `FunctionBuilder` to help with registering functions as well as adding additional documentation and tags. I might eventually steal it for use in spatial as well haha.

Another motivation to introduce this `FunctionBuilder` wrapper is that it will also make it easier to eventually migrate to using DuckDB's new extension C-API, as we can hide the low-level and verbose c-interface behind it.

Right now only scalar functions (and overloads!) are supported, but we can add table functions and aggregates in the future.

There are also a lot of `// TODO: Add Example` strewn around to fill in in the future, although im not sure how we would like examples to be formatted (e.g. short one-liners or multiple paragraphs, with or without results, sqllogictest syntax or markdown?).

Additionally this PR also updates DuckDB + CI to the latest stable version (1.1.3)


#### Short example:

You can now easily find e.g. s2 accessor functions in the catalog by just running:
```sql
SELECT function_name, parameters, description, tags 
FROM duckdb_functions() 
WHERE tags['ext'] = ['geography'] AND tags['category'] = ['accessors'];
----
┌───────────────┬────────────┬────────────────────────────────────────────┬─────────────────────────────────────┐
│ function_name │ parameters │                description                 │                tags                 │
│    varchar    │ varchar[]  │                  varchar                   │        map(varchar, varchar)        │
├───────────────┼────────────┼────────────────────────────────────────────┼─────────────────────────────────────┤
│ s2_y          │ [geog]     │ Returns the y coordinate of the geography. │ {category=accessors, ext=geography} │
│ s2_x          │ [geog]     │ Returns the x coordinate of the geography. │ {category=accessors, ext=geography} │
│ s2_perimeter  │ [geog]     │ Returns the perimeter of the geography.    │ {category=accessors, ext=geography} │
│ s2_length     │ [geog]     │ Returns the length of the geography.       │ {category=accessors, ext=geography} │
│ s2_isempty    │ [geog]     │ Returns true if the geography is empty.    │ {category=accessors, ext=geography} │
│ s2_area       │ [geog]     │ Returns the area of the geography.         │ {category=accessors, ext=geography} │
└───────────────┴────────────┴────────────────────────────────────────────┴─────────────────────────────────────┘


```