### PR TITLE
feat: Add s2_covering_fixed_level()

### DIFF
--- a/src/s2_cell_ops.cpp
+++ b/src/s2_cell_ops.cpp
@@ -153,7 +153,7 @@ struct S2CellUnionToGeography {
             cell_ids[i] = S2CellId(child_ids[item.offset + i]);
           }
 
-          auto cells = S2CellUnion::FromNormalized(std::move(cell_ids));
+          auto cells = S2CellUnion::FromVerbatim(std::move(cell_ids));
           auto poly = make_uniq<S2Polygon>();
           poly->InitToCellUnionBorder(cells);
           s2geography::PolygonGeography geog(std::move(poly));

--- a/src/s2_cell_ops.cpp
+++ b/src/s2_cell_ops.cpp
@@ -10,6 +10,8 @@
 #include "s2_geography_serde.hpp"
 #include "s2_types.hpp"
 
+#include "function_builder.hpp"
+
 namespace duckdb {
 
 namespace duckdb_s2 {
@@ -151,8 +153,8 @@ struct S2CellUnionToGeography {
             cell_ids[i] = S2CellId(child_ids[item.offset + i]);
           }
 
-          // We might be able to speed up this step by using FromNormalized() or
-          // FromVerbatim(), but this is safer.
+          // If this step turns out to be a bottlneck, we can investigate
+          // using S2CellUnion::FromNormalized()
           auto cells = S2CellUnion(std::move(cell_ids));
           auto poly = make_uniq<S2Polygon>();
           poly->InitToCellUnionBorder(cells);
@@ -171,13 +173,35 @@ struct S2CellUnionToGeography {
 // GEOSHilbertCode_r() (which helpfully does not require a previously calculated extent).
 struct S2CellCenterFromWKB {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_cellfromwkb", {LogicalType::BLOB},
-                             Types::S2_CELL_CENTER(), ExecutePointFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_cellfromwkb", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("wkb", LogicalType::BLOB);
+            variant.SetReturnType(Types::S2_CELL_CENTER());
+            variant.SetFunction(ExecutePointFn);
+          });
 
-    auto fn_arbitrary = ScalarFunction("s2_arbitrarycellfromwkb", {LogicalType::BLOB},
-                                       Types::S2_CELL_CENTER(), ExecuteArbitraryFn);
-    ExtensionUtil::RegisterFunction(instance, fn_arbitrary);
+          func.SetDescription("Convert a WKB point directly to S2_CELL_CENTER");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "cellops");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_arbitrarycellfromwkb", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("wkb", LogicalType::BLOB);
+            variant.SetReturnType(Types::S2_CELL_CENTER());
+            variant.SetFunction(ExecuteArbitraryFn);
+          });
+
+          func.SetDescription("Convert the first vertex to S2_CELL_CENTER for sorting.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "cellops");
+        });
   }
 
   static inline void ExecutePointFn(DataChunk& args, ExpressionState& state,
@@ -398,10 +422,21 @@ struct S2CellCenterFromWKB {
 
 struct S2CellCenterFromLonLat {
   static void Register(DatabaseInstance& instance) {
-    auto fn =
-        ScalarFunction("s2_cellfromlonlat", {LogicalType::DOUBLE, LogicalType::DOUBLE},
-                       Types::S2_CELL_CENTER(), ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_cellfromlonlat", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("lon", LogicalType::DOUBLE);
+            variant.AddParameter("lat", LogicalType::DOUBLE);
+            variant.SetReturnType(Types::S2_CELL_CENTER());
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription("Convert a lon/lat pair to S2_CELL_CENTER");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "cellops");
+        });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -489,9 +524,21 @@ struct S2CellToGeography {
 
 struct S2CellVertex {
   static void Register(DatabaseInstance& instance) {
-    auto fn = ScalarFunction("s2_cell_vertex", {Types::S2_CELL(), LogicalType::TINYINT},
-                             Types::GEOGRAPHY(), Execute);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_cell_vertex", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("cell_id", Types::S2_CELL());
+            variant.AddParameter("vertex_id", LogicalType::TINYINT);
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(Execute);
+          });
+
+          func.SetDescription("Returns the vertex of the S2 cell.");
+          // TODO: Example
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "cellops");
+        });
   }
 
   static inline void Execute(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -512,8 +559,19 @@ struct S2CellVertex {
 template <typename Op>
 struct S2CellToString {
   static void Register(DatabaseInstance& instance, const char* name) {
-    auto fn = ScalarFunction(name, {Types::S2_CELL()}, LogicalType::VARCHAR, ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("cell", Types::S2_CELL());
+        variant.SetReturnType(LogicalType::VARCHAR);
+        variant.SetFunction(ExecuteFn);
+      });
+
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -539,8 +597,19 @@ struct S2CellToString {
 template <typename Op>
 struct S2CellFromString {
   static void Register(DatabaseInstance& instance, const char* name) {
-    auto fn = ScalarFunction(name, {LogicalType::VARCHAR}, Types::S2_CELL(), ExecuteFn);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("text", LogicalType::VARCHAR);
+        variant.SetReturnType(Types::S2_CELL());
+        variant.SetFunction(ExecuteFn);
+      });
+
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -565,8 +634,19 @@ struct S2CellFromString {
 template <typename Op>
 struct S2CellToDouble {
   static void Register(DatabaseInstance& instance, const char* name) {
-    auto fn = ScalarFunction(name, {Types::S2_CELL()}, LogicalType::DOUBLE, Execute);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [](ScalarFunctionBuilder& func) {
+      func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("cell", Types::S2_CELL());
+        variant.SetReturnType(LogicalType::DOUBLE);
+        variant.SetFunction(Execute);
+      });
+
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void Execute(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -581,8 +661,19 @@ template <typename Op>
 struct S2CellToInt8 {
   static void Register(DatabaseInstance& instance, const char* name,
                        LogicalType arg_type) {
-    auto fn = ScalarFunction(name, {arg_type}, LogicalType::TINYINT, Execute);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [&](ScalarFunctionBuilder& func) {
+      func.AddVariant([&](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("cell", arg_type);
+        variant.SetReturnType(LogicalType::TINYINT);
+        variant.SetFunction(Execute);
+      });
+
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void Execute(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -596,9 +687,19 @@ struct S2CellToInt8 {
 template <typename Op>
 struct S2BinaryCellPredicate {
   static void Register(DatabaseInstance& instance, const char* name) {
-    auto fn = ScalarFunction(name, {Types::S2_CELL(), Types::S2_CELL()},
-                             LogicalType::BOOLEAN, Execute);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [&](ScalarFunctionBuilder& func) {
+      func.AddVariant([&](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("cell1", Types::S2_CELL());
+        variant.AddParameter("cell2", Types::S2_CELL());
+        variant.SetReturnType(LogicalType::BOOLEAN);
+        variant.SetFunction(Execute);
+      });
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void Execute(DataChunk& args, ExpressionState& state, Vector& result) {
@@ -612,9 +713,20 @@ struct S2BinaryCellPredicate {
 template <typename Op>
 struct S2CellToCell {
   static void Register(DatabaseInstance& instance, const char* name) {
-    auto fn = ScalarFunction(name, {Types::S2_CELL(), LogicalType::TINYINT},
-                             Types::S2_CELL(), Execute);
-    ExtensionUtil::RegisterFunction(instance, fn);
+    FunctionBuilder::RegisterScalar(instance, name, [&](ScalarFunctionBuilder& func) {
+      func.AddVariant([&](ScalarFunctionVariantBuilder& variant) {
+        variant.AddParameter("cell", Types::S2_CELL());
+        variant.AddParameter("index", LogicalType::TINYINT);
+        variant.SetReturnType(Types::S2_CELL());
+        variant.SetFunction(Execute);
+      });
+
+      // TODO: Description
+      // TODO: Example
+
+      func.SetTag("ext", "geography");
+      func.SetTag("category", "cellops");
+    });
   }
 
   static inline void Execute(DataChunk& args, ExpressionState& state, Vector& result) {

--- a/src/s2_cell_ops.cpp
+++ b/src/s2_cell_ops.cpp
@@ -153,8 +153,9 @@ struct S2CellUnionToGeography {
             cell_ids[i] = S2CellId(child_ids[item.offset + i]);
           }
 
-          // If this step turns out to be a bottlneck, we can investigate
-          // using S2CellUnion::FromNormalized()
+          // If this step turns out to be a bottleneck, we can investigate
+          // using S2CellUnion::FromNormalized() and requiring the caller to
+          // explicitly normalize first.
           auto cells = S2CellUnion(std::move(cell_ids));
           auto poly = make_uniq<S2Polygon>();
           poly->InitToCellUnionBorder(cells);

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -10,8 +10,23 @@ SELECT s2_covering(s2_data_country('Fiji'));
 ----
 [3/13002011, 3/1300232, 3/130030, 3/130031, 3/130033, 3/130100, 3/2032333, 3/20330000000]
 
+query I
+SELECT s2_covering_fixed_level(s2_data_country('Fiji'), 5);
+----
+[3/13002, 3/13003, 3/13010, 3/20323, 3/20330]
+
 # Check optimization for the cell center geography
 query I
 SELECT s2_covering('POINT (-64 45)'::GEOGRAPHY::S2_CELL_CENTER);
 ----
 [2/112230310012123001312232330210]
+
+query I
+SELECT s2_covering_fixed_level('POINT (-64 45)'::GEOGRAPHY::S2_CELL_CENTER, 5);
+----
+[2/11223]
+
+statement error
+SELECT s2_covering_fixed_level(geog, UNNEST([1, 2])) from s2_data_countries();
+----
+Invalid Input Error: s2_covering_fixed_level(): level must be a constant


### PR DESCRIPTION
Adds a function for generating a covering with a fixed level. Useful for hijacking an equality join to do preselection!

```
query I
SELECT s2_covering_fixed_level(s2_data_country('Fiji'), 5);
----
[3/13002, 3/13003, 3/13010, 3/20323, 3/20330]

query I
SELECT s2_covering_fixed_level('POINT (-64 45)'::GEOGRAPHY::S2_CELL_CENTER, 5);
----
[2/11223]

statement error
SELECT s2_covering_fixed_level(geog, UNNEST([1, 2])) from s2_data_countries();
----
Invalid Input Error: s2_covering_fixed_level(): level must be a constant
```