### PR TITLE
feat: Add s2_bounds_box() and s2_bounds_agg()

### DIFF
--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -9,6 +9,9 @@
 | [`s2_perimeter`](#s2_perimeter) | Calculate the perimeter of the geography in meters.|
 | [`s2_x`](#s2_x) | Extract the longitude of a point geography.|
 | [`s2_y`](#s2_y) | Extract the latitude of a point geography.|
+| [`s2_bounds_rect`](#s2_bounds_rect) | Returns the bounds of the input geography as a box with Cartesian edges.|
+| [`s2_box_struct`](#s2_box_struct) | Return a BOX_LNGLAT storage as a struct(xmin, ymin, xmax, ymax).|
+| [`s2_box_wkb`](#s2_box_wkb) | Serialize a BOX_LNGLAT as WKB for export.|
 | [`s2_covering`](#s2_covering) | Returns the S2 cell covering of the geography.|
 | [`s2_covering_fixed_level`](#s2_covering_fixed_level) | Returns the S2 cell covering of the geography with a fixed level.|
 | [`s2_arbitrarycellfromwkb`](#s2_arbitrarycellfromwkb) | Get an arbitrary S2_CELL_CENTER on or near the input.|
@@ -223,6 +226,79 @@ SELECT s2_y('POINT (-64 45)'::GEOGRAPHY);
 --└───────────────────────────────────────────┘
 ```
 ## Bounds
+
+### s2_bounds_rect
+
+Returns the bounds of the input geography as a box with Cartesian edges.
+
+```sql
+BOX_LNGLAT s2_bounds_rect(geog GEOGRAPHY)
+```
+
+#### Description
+
+The output xmin may be greater than xmax if the geography crosses the
+antimeridian.
+
+#### Example
+
+```sql
+SELECT s2_bounds_rect(s2_data_country('Germany')) as rect;
+--┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
+--│                                                 rect                                                  │
+--│                                              box_lnglat                                               │
+--├───────────────────────────────────────────────────────────────────────────────────────────────────────┤
+--│ {'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026} │
+--└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+SELECT s2_bounds_rect(s2_data_country('Fiji')) as rect;
+--┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+--│                                               rect                                               │
+--│                                            box_lnglat                                            │
+--├──────────────────────────────────────────────────────────────────────────────────────────────────┤
+--│ {'xmin': 177.28504, 'ymin': -18.28799000000003, 'xmax': -179.79332, 'ymax': -16.020881999999975} │
+--└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### s2_box_struct
+
+Return a BOX_LNGLAT storage as a struct(xmin, ymin, xmax, ymax).
+
+```sql
+STRUCT(xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE) s2_box_struct(box BOX_LNGLAT)
+```
+
+#### Example
+
+```sql
+SELECT s2_box_struct(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
+--┌────────────────────────────────────────────────────────────┐
+--│                            rect                            │
+--│ struct(xmin double, ymin double, xmax double, ymax double) │
+--├────────────────────────────────────────────────────────────┤
+--│ {'xmin': 0.0, 'ymin': 1.0, 'xmax': 0.0, 'ymax': 1.0}       │
+--└────────────────────────────────────────────────────────────┘
+```
+
+### s2_box_wkb
+
+Serialize a BOX_LNGLAT as WKB for export.
+
+```sql
+BLOB s2_box_wkb(box BOX_LNGLAT)
+```
+
+#### Example
+
+```sql
+SELECT s2_box_wkb(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
+--┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+--│                                                         rect                                                         │
+--│                                                         blob                                                         │
+--├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+--│ \x01\x03\x00\x00\x00\x01\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xF0?\…  │
+--└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
 
 ### s2_covering
 

--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -10,8 +10,8 @@
 | [`s2_x`](#s2_x) | Extract the longitude of a point geography.|
 | [`s2_y`](#s2_y) | Extract the latitude of a point geography.|
 | [`s2_bounds_rect`](#s2_bounds_rect) | Returns the bounds of the input geography as a box with Cartesian edges.|
-| [`s2_box_struct`](#s2_box_struct) | Return a BOX_LNGLAT storage as a struct(xmin, ymin, xmax, ymax).|
-| [`s2_box_wkb`](#s2_box_wkb) | Serialize a BOX_LNGLAT as WKB for export.|
+| [`s2_box_struct`](#s2_box_struct) | Return a S2_BOX storage as a struct(xmin, ymin, xmax, ymax).|
+| [`s2_box_wkb`](#s2_box_wkb) | Serialize a S2_BOX as WKB for export.|
 | [`s2_covering`](#s2_covering) | Returns the S2 cell covering of the geography.|
 | [`s2_covering_fixed_level`](#s2_covering_fixed_level) | Returns the S2 cell covering of the geography with a fixed level.|
 | [`s2_arbitrarycellfromwkb`](#s2_arbitrarycellfromwkb) | Get an arbitrary S2_CELL_CENTER on or near the input.|
@@ -232,7 +232,7 @@ SELECT s2_y('POINT (-64 45)'::GEOGRAPHY);
 Returns the bounds of the input geography as a box with Cartesian edges.
 
 ```sql
-BOX_LNGLAT s2_bounds_rect(geog GEOGRAPHY)
+S2_BOX s2_bounds_rect(geog GEOGRAPHY)
 ```
 
 #### Description
@@ -246,7 +246,7 @@ antimeridian.
 SELECT s2_bounds_rect(s2_data_country('Germany')) as rect;
 --┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
 --│                                                 rect                                                  │
---│                                              box_lnglat                                               │
+--│                                              S2_BOX                                               │
 --├───────────────────────────────────────────────────────────────────────────────────────────────────────┤
 --│ {'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026} │
 --└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
@@ -254,7 +254,7 @@ SELECT s2_bounds_rect(s2_data_country('Germany')) as rect;
 SELECT s2_bounds_rect(s2_data_country('Fiji')) as rect;
 --┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
 --│                                               rect                                               │
---│                                            box_lnglat                                            │
+--│                                            S2_BOX                                            │
 --├──────────────────────────────────────────────────────────────────────────────────────────────────┤
 --│ {'xmin': 177.28504, 'ymin': -18.28799000000003, 'xmax': -179.79332, 'ymax': -16.020881999999975} │
 --└──────────────────────────────────────────────────────────────────────────────────────────────────┘
@@ -262,10 +262,10 @@ SELECT s2_bounds_rect(s2_data_country('Fiji')) as rect;
 
 ### s2_box_struct
 
-Return a BOX_LNGLAT storage as a struct(xmin, ymin, xmax, ymax).
+Return a S2_BOX storage as a struct(xmin, ymin, xmax, ymax).
 
 ```sql
-STRUCT(xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE) s2_box_struct(box BOX_LNGLAT)
+STRUCT(xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE) s2_box_struct(box S2_BOX)
 ```
 
 #### Example
@@ -282,10 +282,10 @@ SELECT s2_box_struct(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
 
 ### s2_box_wkb
 
-Serialize a BOX_LNGLAT as WKB for export.
+Serialize a S2_BOX as WKB for export.
 
 ```sql
-BLOB s2_box_wkb(box BOX_LNGLAT)
+BLOB s2_box_wkb(box S2_BOX)
 ```
 
 #### Example

--- a/src/include/s2_types.hpp
+++ b/src/include/s2_types.hpp
@@ -12,7 +12,7 @@ struct Types {
   static LogicalType S2_CELL_UNION();
   static LogicalType S2_CELL_CENTER();
   static LogicalType GEOGRAPHY();
-  static LogicalType BOX_LNGLAT();
+  static LogicalType S2_BOX();
 };
 
 void RegisterTypes(DatabaseInstance& instance);

--- a/src/include/s2_types.hpp
+++ b/src/include/s2_types.hpp
@@ -12,6 +12,7 @@ struct Types {
   static LogicalType S2_CELL_UNION();
   static LogicalType S2_CELL_CENTER();
   static LogicalType GEOGRAPHY();
+  static LogicalType BOX_LNGLAT();
 };
 
 void RegisterTypes(DatabaseInstance& instance);

--- a/src/s2_bounds.cpp
+++ b/src/s2_bounds.cpp
@@ -348,28 +348,31 @@ SELECT s2_box_wkb(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
     char* coords = const_cast<char*>(encoder.base() + encoder_coord_offset);
 
     Encoder multi_encoder;
-    // multi_encoder.Ensure(92 * 2 + 8 + 1);
-    // multi_encoder.put8(0x01);
-    // multi_encoder.put32(6);
-    // multi_encoder.put32(2);
-    // multi_encoder.put32(3);
-    // multi_encoder.put32(1);
-    // multi_encoder.put32(5);
-    size_t multi_encoder_coord_offset_east = encoder.length();
-    // for (int i = 0; i < 10; i++) {
-    //   encoder.put64(0);
-    // }
-    // multi_encoder.put32(3);
-    // multi_encoder.put32(1);
-    // multi_encoder.put32(5);
-    size_t multi_encoder_coord_offset_west = encoder.length();
-    // for (int i = 0; i < 10; i++) {
-    //   encoder.put64(0);
-    // }
+    multi_encoder.Ensure(93 * 2 + 8 + 1);
+    multi_encoder.put8(0x01);
+    multi_encoder.put32(6);
+    multi_encoder.put32(2);
+    multi_encoder.put8(0x01);
+    multi_encoder.put32(3);
+    multi_encoder.put32(1);
+    multi_encoder.put32(5);
+    size_t multi_encoder_coord_offset_east = multi_encoder.length();
+    for (int i = 0; i < 10; i++) {
+      multi_encoder.put64(0);
+    }
+
+    multi_encoder.put8(0x01);
+    multi_encoder.put32(3);
+    multi_encoder.put32(1);
+    multi_encoder.put32(5);
+    size_t multi_encoder_coord_offset_west = multi_encoder.length();
+    for (int i = 0; i < 10; i++) {
+      multi_encoder.put64(0);
+    }
     char* multi_coords_east =
-        const_cast<char*>(encoder.base() + multi_encoder_coord_offset_east);
+        const_cast<char*>(multi_encoder.base() + multi_encoder_coord_offset_east);
     char* multi_coords_west =
-        const_cast<char*>(encoder.base() + multi_encoder_coord_offset_west);
+        const_cast<char*>(multi_encoder.base() + multi_encoder_coord_offset_west);
 
     auto count = args.size();
     auto& source = args.data[0];
@@ -381,11 +384,11 @@ SELECT s2_box_wkb(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
           auto ymax = box.d_val;
           if (xmax >= xmin) {
             PopulateCoordsFromValues(coords, xmin, ymin, xmax, ymax);
-            return StringVector::AddStringOrBlob(result,
-                                           string_t(encoder.base(), encoder.length()));
+            return StringVector::AddStringOrBlob(
+                result, string_t(encoder.base(), encoder.length()));
           } else {
-            PopulateCoordsFromValues(multi_coords_east, xmin, ymin, -180, ymax);
-            PopulateCoordsFromValues(multi_coords_west, xmax, ymin, 180, ymax);
+            PopulateCoordsFromValues(multi_coords_east, xmin, ymin, 180, ymax);
+            PopulateCoordsFromValues(multi_coords_west, -180, ymin, xmax, ymax);
             return StringVector::AddStringOrBlob(
                 result, string_t(multi_encoder.base(), multi_encoder.length()));
           }

--- a/src/s2_bounds.cpp
+++ b/src/s2_bounds.cpp
@@ -151,10 +151,10 @@ SELECT s2_covering_fixed_level(s2_data_country('Germany'), 4) AS covering;
 struct S2BoundsRect {
   static void Register(DatabaseInstance& instance) {
     FunctionBuilder::RegisterScalar(
-        instance, "s2_bounds_rect", [](ScalarFunctionBuilder& func) {
+        instance, "s2_bounds_box", [](ScalarFunctionBuilder& func) {
           func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
             variant.AddParameter("geog", Types::GEOGRAPHY());
-            variant.SetReturnType(Types::BOX_LNGLAT());
+            variant.SetReturnType(Types::S2_BOX());
             variant.SetFunction(ExecuteFn);
           });
 
@@ -166,9 +166,9 @@ The output xmin may be greater than xmax if the geography crosses the
 antimeridian.
 )");
           func.SetExample(R"(
-SELECT s2_bounds_rect(s2_data_country('Germany')) as rect;
+SELECT s2_bounds_box(s2_data_country('Germany')) as rect;
 ----
-SELECT s2_bounds_rect(s2_data_country('Fiji')) as rect;
+SELECT s2_bounds_box(s2_data_country('Fiji')) as rect;
           )");
 
           func.SetTag("ext", "geography");
@@ -315,10 +315,10 @@ struct S2BoundsRectAgg {
 void RegisterAgg(DatabaseInstance& instance) {
   auto function = AggregateFunction::UnaryAggregate<BoundsAggState, string_t, string_t,
                                                     S2BoundsRectAgg>(Types::GEOGRAPHY(),
-                                                                     Types::BOX_LNGLAT());
+                                                                     Types::S2_BOX());
 
   // Register the function
-  function.name = "s2_bounds_rect_agg";
+  function.name = "s2_bounds_box_agg";
   ExtensionUtil::RegisterFunction(instance, function);
 }
 
@@ -327,17 +327,17 @@ struct S2BoxLngLatAsWkb {
     FunctionBuilder::RegisterScalar(
         instance, "s2_box_wkb", [](ScalarFunctionBuilder& func) {
           func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
-            variant.AddParameter("box", Types::BOX_LNGLAT());
+            variant.AddParameter("box", Types::S2_BOX());
             variant.SetReturnType(LogicalType::BLOB);
             variant.SetFunction(ExecuteFn);
           });
 
           func.SetDescription(
               R"(
-Serialize a BOX_LNGLAT as WKB for export.
+Serialize a S2_BOX as WKB for export.
 )");
           func.SetExample(R"(
-SELECT s2_box_wkb(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
+SELECT s2_box_wkb(s2_bounds_box('POINT (0 1)'::GEOGRAPHY)) as rect;
           )");
 
           func.SetTag("ext", "geography");
@@ -431,7 +431,7 @@ struct S2BoxStruct {
     FunctionBuilder::RegisterScalar(
         instance, "s2_box_struct", [](ScalarFunctionBuilder& func) {
           func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
-            variant.AddParameter("box", Types::BOX_LNGLAT());
+            variant.AddParameter("box", Types::S2_BOX());
             variant.SetReturnType(LogicalType::STRUCT({{"xmin", LogicalType::DOUBLE},
                                                        {"ymin", LogicalType::DOUBLE},
                                                        {"xmax", LogicalType::DOUBLE},
@@ -441,10 +441,10 @@ struct S2BoxStruct {
 
           func.SetDescription(
               R"(
-Return a BOX_LNGLAT storage as a struct(xmin, ymin, xmax, ymax).
+Return a S2_BOX storage as a struct(xmin, ymin, xmax, ymax).
 )");
           func.SetExample(R"(
-SELECT s2_box_struct(s2_bounds_rect('POINT (0 1)'::GEOGRAPHY)) as rect;
+SELECT s2_box_struct(s2_bounds_box('POINT (0 1)'::GEOGRAPHY)) as rect;
           )");
 
           func.SetTag("ext", "geography");

--- a/src/s2_bounds.cpp
+++ b/src/s2_bounds.cpp
@@ -452,7 +452,7 @@ struct S2Box {
           R"(
 Create a S2_BOX from xmin (west), ymin (south), xmax (east), and ymax (north).
 
-Note that any box where ymin > ymax is considere EMPTY for the purposes of
+Note that any box where ymin > ymax is considered EMPTY for the purposes of
 comparison.
 )");
       func.SetExample(R"(

--- a/src/s2_bounds.cpp
+++ b/src/s2_bounds.cpp
@@ -199,10 +199,10 @@ SELECT s2_bounds_rect(s2_data_country('Fiji')) as rect;
 
         decoder.DecodeTag(blob);
         if (decoder.tag.flags & s2geography::EncodeTag::kFlagEmpty) {
-          min_x_data[i] = NAN;
-          min_y_data[i] = NAN;
-          max_x_data[i] = NAN;
-          max_y_data[i] = NAN;
+          // Empty input, return null. This ensures that we never have to check
+          // for nan, nan, nan, nan before doing anything with a (non null)
+          // value.
+          FlatVector::SetNull(result, i, true);
         } else if (decoder.tag.kind == s2geography::GeographyKind::CELL_CENTER) {
           uint64_t cell_id = LittleEndian::Load64(blob.GetData() + 4);
           S2CellId cell(cell_id);

--- a/src/s2_types.cpp
+++ b/src/s2_types.cpp
@@ -32,12 +32,12 @@ LogicalType Types::GEOGRAPHY() {
   return type;
 }
 
-LogicalType Types::BOX_LNGLAT() {
+LogicalType Types::S2_BOX() {
   LogicalType type = LogicalType::STRUCT({{"xmin", LogicalType::DOUBLE},
                                           {"ymin", LogicalType::DOUBLE},
                                           {"xmax", LogicalType::DOUBLE},
                                           {"ymax", LogicalType::DOUBLE}});
-  type.SetAlias("BOX_LNGLAT");
+  type.SetAlias("S2_BOX");
   return type;
 }
 
@@ -46,7 +46,7 @@ void RegisterTypes(DatabaseInstance& instance) {
   ExtensionUtil::RegisterType(instance, "S2_CELL_UNION", Types::S2_CELL_UNION());
   ExtensionUtil::RegisterType(instance, "S2_CELL_CENTER", Types::S2_CELL_CENTER());
   ExtensionUtil::RegisterType(instance, "GEOGRAPHY", Types::GEOGRAPHY());
-  ExtensionUtil::RegisterType(instance, "BOX_LNGLAT", Types::BOX_LNGLAT());
+  ExtensionUtil::RegisterType(instance, "S2_BOX", Types::S2_BOX());
 }
 
 }  // namespace duckdb_s2

--- a/src/s2_types.cpp
+++ b/src/s2_types.cpp
@@ -32,11 +32,21 @@ LogicalType Types::GEOGRAPHY() {
   return type;
 }
 
+LogicalType Types::BOX_LNGLAT() {
+  LogicalType type = LogicalType::STRUCT({{"xmin", LogicalType::DOUBLE},
+                                          {"ymin", LogicalType::DOUBLE},
+                                          {"xmax", LogicalType::DOUBLE},
+                                          {"ymax", LogicalType::DOUBLE}});
+  type.SetAlias("BOX_LNGLAT");
+  return type;
+}
+
 void RegisterTypes(DatabaseInstance& instance) {
   ExtensionUtil::RegisterType(instance, "S2_CELL", Types::S2_CELL());
   ExtensionUtil::RegisterType(instance, "S2_CELL_UNION", Types::S2_CELL_UNION());
   ExtensionUtil::RegisterType(instance, "S2_CELL_CENTER", Types::S2_CELL_CENTER());
   ExtensionUtil::RegisterType(instance, "GEOGRAPHY", Types::GEOGRAPHY());
+  ExtensionUtil::RegisterType(instance, "BOX_LNGLAT", Types::BOX_LNGLAT());
 }
 
 }  // namespace duckdb_s2

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -30,3 +30,22 @@ statement error
 SELECT s2_covering_fixed_level(geog, UNNEST([1, 2])) from s2_data_countries();
 ----
 Invalid Input Error: s2_covering_fixed_level(): level must be a constant
+
+# s2_bounds_rect()
+query I
+SELECT s2_bounds_rect(NULL) IS NULL;
+----
+true
+
+# Check empty input optimization
+# Possibly should be NULL and not nans?
+query I
+SELECT s2_bounds_rect('POINT EMPTY'::GEOGRAPHY);
+----
+{'xmin': nan, 'ymin': nan, 'xmax': nan, 'ymax': nan}
+
+# Check
+query I
+SELECT s2_cellfromlonlat(-64, 45).s2_bounds_rect();
+----
+{'xmin': -63.99999997805, 'ymin': 45.0000000116166, 'xmax': -63.99999997805, 'ymax': 45.0000000116166}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -97,6 +97,11 @@ SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_wkb().s2_geogfromwkb().
 POLYGON ((5.9887 47.3025, 15.017 47.3025, 15.017 54.9831, 5.9887 54.9831, 5.9887 47.3025))
 
 query I
+SELECT s2_bounds_rect(s2_data_country('Fiji')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
+----
+MULTIPOLYGON (((177.285 -18.288, 180 -18.288, 180 -16.0209, 177.285 -16.0209, 177.285 -18.288)), ((-180 -18.288, -179.7933 -18.288, -179.7933 -16.0209, -180 -16.0209, -180 -18.288)))
+
+query I
 SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_struct();
 ----
 {'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -56,9 +56,6 @@ SELECT s2_bounds_rect('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
 {'xmin': 0.0, 'ymin': 1.0, 'xmax': 1.9999999999999996, 'ymax': 3.0000000000000004}
 
 # s2_bounds_rect_agg()
-# These results aren't really correct until I figure out how to either
-# encode the result of an aggregate as a struct or change the storage of the
-# box_lnglat to be a blob.
 
 # Check empty input optimization
 query I

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -70,21 +70,21 @@ true
 query I
 SELECT s2_bounds_rect_agg(s2_cellfromlonlat(-64, 45));
 ----
-[-64.000000, 45.000000, -64.000000, 45.000000]
+{'xmin': -63.99999997805, 'ymin': 45.0000000116166, 'xmax': -63.99999997805, 'ymax': 45.0000000116166}
 
 # Check normal encoded geography
 query I
 SELECT s2_bounds_rect_agg('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
 ----
-[0.000000, 1.000000, 2.000000, 3.000000]
+{'xmin': 0.0, 'ymin': 1.0, 'xmax': 1.9999999999999996, 'ymax': 3.0000000000000004}
 
 # With some actual aggregation
 query I
 SELECT s2_bounds_rect_agg(geog) FROM s2_data_cities();
 ----
-[-123.123590, -41.299988, -171.738642, 64.150024]
+{'xmin': -123.12359, 'ymin': -41.29998789999999, 'xmax': -171.738642, 'ymax': 64.1500236}
 
 query I
 SELECT s2_bounds_rect_agg(geog) FROM s2_data_countries();
 ----
-[-180.000000, -90.000000, 180.000000, 83.645130]
+{'xmin': -180.0, 'ymin': -90.0, 'xmax': 180.0, 'ymax': 83.64513000000002}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -88,3 +88,15 @@ query I
 SELECT s2_bounds_rect_agg(geog) FROM s2_data_countries();
 ----
 {'xmin': -180.0, 'ymin': -90.0, 'xmax': 180.0, 'ymax': 83.64513000000002}
+
+
+# Test the box exporters
+query I
+SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
+----
+POLYGON ((5.9887 47.3025, 15.017 47.3025, 15.017 54.9831, 5.9887 54.9831, 5.9887 47.3025))
+
+query I
+SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_struct();
+----
+{'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -102,3 +102,9 @@ query I
 SELECT s2_bounds_box(s2_data_country('Germany')).s2_box_struct();
 ----
 {'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026}
+
+# Test box constructor
+query I
+SELECT s2_box(5.989, 47.302, 15.017, 54.983);
+----
+{'xmin': 5.989, 'ymin': 47.302, 'xmax': 15.017, 'ymax': 54.983}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -43,8 +43,48 @@ SELECT s2_bounds_rect('POINT EMPTY'::GEOGRAPHY) IS NULL;
 ----
 true
 
-# Check
+# Check point-as-cell-center optimization
 query I
 SELECT s2_cellfromlonlat(-64, 45).s2_bounds_rect();
 ----
 {'xmin': -63.99999997805, 'ymin': 45.0000000116166, 'xmax': -63.99999997805, 'ymax': 45.0000000116166}
+
+# Check normal encoded geography
+query I
+SELECT s2_bounds_rect('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
+----
+{'xmin': 0.0, 'ymin': 1.0, 'xmax': 1.9999999999999996, 'ymax': 3.0000000000000004}
+
+# s2_bounds_rect_agg()
+# These results aren't really correct until I figure out how to either
+# encode the result of an aggregate as a struct or change the storage of the
+# box_lnglat to be a blob.
+
+# Check empty input optimization
+query I
+SELECT s2_bounds_rect_agg('POINT EMPTY'::GEOGRAPHY) IS NULL;
+----
+true
+
+# Check point-as-cell-center optimization
+query I
+SELECT s2_bounds_rect_agg(s2_cellfromlonlat(-64, 45));
+----
+[-64.000000, 45.000000, -64.000000, 45.000000]
+
+# Check normal encoded geography
+query I
+SELECT s2_bounds_rect_agg('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
+----
+[0.000000, 1.000000, 2.000000, 3.000000]
+
+# With some actual aggregation
+query I
+SELECT s2_bounds_rect_agg(geog) FROM s2_data_cities();
+----
+[-123.123590, -41.299988, -171.738642, 64.150024]
+
+query I
+SELECT s2_bounds_rect_agg(geog) FROM s2_data_countries();
+----
+[-180.000000, -90.000000, 180.000000, 83.645130]

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -108,3 +108,25 @@ query I
 SELECT s2_box(5.989, 47.302, 15.017, 54.983);
 ----
 {'xmin': 5.989, 'ymin': 47.302, 'xmax': 15.017, 'ymax': 54.983}
+
+# s2_box_intersects()
+query I
+SELECT s2_box_intersects(s2_bounds_box(s2_data_country('Germany')), s2_bounds_box(s2_data_country('France')));
+----
+true
+
+query I
+SELECT s2_box_intersects(s2_bounds_box(s2_data_country('Germany')), s2_bounds_box(s2_data_country('Canada')));
+----
+false
+
+# s2_box_union()
+query I
+SELECT s2_box_union(s2_box(0, 1, 2, 3), s2_box(4, 5, 6, 7));
+----
+{'xmin': 0.0, 'ymin': 1.0, 'xmax': 6.000000000000001, 'ymax': 7.0}
+
+query I
+SELECT s2_box_union(s2_box(179, 1, 180, 3), s2_box(-180, 5, -179, 7));
+----
+{'xmin': 179.0, 'ymin': 1.0, 'xmax': -179.0, 'ymax': 7.0}

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -32,16 +32,11 @@ SELECT s2_covering_fixed_level(geog, UNNEST([1, 2])) from s2_data_countries();
 Invalid Input Error: s2_covering_fixed_level(): level must be a constant
 
 # s2_bounds_box()
-query I
-SELECT s2_bounds_box(NULL) IS NULL;
-----
-true
-
 # Check empty input optimization
 query I
-SELECT s2_bounds_box('POINT EMPTY'::GEOGRAPHY) IS NULL;
+SELECT s2_bounds_box('POINT EMPTY'::GEOGRAPHY);
 ----
-true
+{'xmin': 180.0, 'ymin': 57.29577951308232, 'xmax': -180.0, 'ymax': 0.0}
 
 # Check point-as-cell-center optimization
 query I
@@ -59,9 +54,9 @@ SELECT s2_bounds_box('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
 
 # Check empty input optimization
 query I
-SELECT s2_bounds_box_agg('POINT EMPTY'::GEOGRAPHY) IS NULL;
+SELECT s2_bounds_box_agg('POINT EMPTY'::GEOGRAPHY);
 ----
-true
+{'xmin': 180.0, 'ymin': 57.29577951308232, 'xmax': -180.0, 'ymax': 0.0}
 
 # Check point-as-cell-center optimization
 query I

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -38,11 +38,10 @@ SELECT s2_bounds_rect(NULL) IS NULL;
 true
 
 # Check empty input optimization
-# Possibly should be NULL and not nans?
 query I
-SELECT s2_bounds_rect('POINT EMPTY'::GEOGRAPHY);
+SELECT s2_bounds_rect('POINT EMPTY'::GEOGRAPHY) IS NULL;
 ----
-{'xmin': nan, 'ymin': nan, 'xmax': nan, 'ymax': nan}
+true
 
 # Check
 query I

--- a/test/sql/bounds.test
+++ b/test/sql/bounds.test
@@ -31,74 +31,74 @@ SELECT s2_covering_fixed_level(geog, UNNEST([1, 2])) from s2_data_countries();
 ----
 Invalid Input Error: s2_covering_fixed_level(): level must be a constant
 
-# s2_bounds_rect()
+# s2_bounds_box()
 query I
-SELECT s2_bounds_rect(NULL) IS NULL;
+SELECT s2_bounds_box(NULL) IS NULL;
 ----
 true
 
 # Check empty input optimization
 query I
-SELECT s2_bounds_rect('POINT EMPTY'::GEOGRAPHY) IS NULL;
+SELECT s2_bounds_box('POINT EMPTY'::GEOGRAPHY) IS NULL;
 ----
 true
 
 # Check point-as-cell-center optimization
 query I
-SELECT s2_cellfromlonlat(-64, 45).s2_bounds_rect();
+SELECT s2_cellfromlonlat(-64, 45).s2_bounds_box();
 ----
 {'xmin': -63.99999997805, 'ymin': 45.0000000116166, 'xmax': -63.99999997805, 'ymax': 45.0000000116166}
 
 # Check normal encoded geography
 query I
-SELECT s2_bounds_rect('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
+SELECT s2_bounds_box('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
 ----
 {'xmin': 0.0, 'ymin': 1.0, 'xmax': 1.9999999999999996, 'ymax': 3.0000000000000004}
 
-# s2_bounds_rect_agg()
+# s2_bounds_box_agg()
 
 # Check empty input optimization
 query I
-SELECT s2_bounds_rect_agg('POINT EMPTY'::GEOGRAPHY) IS NULL;
+SELECT s2_bounds_box_agg('POINT EMPTY'::GEOGRAPHY) IS NULL;
 ----
 true
 
 # Check point-as-cell-center optimization
 query I
-SELECT s2_bounds_rect_agg(s2_cellfromlonlat(-64, 45));
+SELECT s2_bounds_box_agg(s2_cellfromlonlat(-64, 45));
 ----
 {'xmin': -63.99999997805, 'ymin': 45.0000000116166, 'xmax': -63.99999997805, 'ymax': 45.0000000116166}
 
 # Check normal encoded geography
 query I
-SELECT s2_bounds_rect_agg('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
+SELECT s2_bounds_box_agg('MULTIPOINT (0 1, 2 3)'::GEOGRAPHY);
 ----
 {'xmin': 0.0, 'ymin': 1.0, 'xmax': 1.9999999999999996, 'ymax': 3.0000000000000004}
 
 # With some actual aggregation
 query I
-SELECT s2_bounds_rect_agg(geog) FROM s2_data_cities();
+SELECT s2_bounds_box_agg(geog) FROM s2_data_cities();
 ----
 {'xmin': -123.12359, 'ymin': -41.29998789999999, 'xmax': -171.738642, 'ymax': 64.1500236}
 
 query I
-SELECT s2_bounds_rect_agg(geog) FROM s2_data_countries();
+SELECT s2_bounds_box_agg(geog) FROM s2_data_countries();
 ----
 {'xmin': -180.0, 'ymin': -90.0, 'xmax': 180.0, 'ymax': 83.64513000000002}
 
 
 # Test the box exporters
 query I
-SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
+SELECT s2_bounds_box(s2_data_country('Germany')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
 ----
 POLYGON ((5.9887 47.3025, 15.017 47.3025, 15.017 54.9831, 5.9887 54.9831, 5.9887 47.3025))
 
 query I
-SELECT s2_bounds_rect(s2_data_country('Fiji')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
+SELECT s2_bounds_box(s2_data_country('Fiji')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
 ----
 MULTIPOLYGON (((177.285 -18.288, 180 -18.288, 180 -16.0209, 177.285 -16.0209, 177.285 -18.288)), ((-180 -18.288, -179.7933 -18.288, -179.7933 -16.0209, -180 -16.0209, -180 -18.288)))
 
 query I
-SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_struct();
+SELECT s2_bounds_box(s2_data_country('Germany')).s2_box_struct();
 ----
 {'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026}


### PR DESCRIPTION
Adds `s2_bounds_rect()` and `s2_bounds_rect_agg()` and the tools to extract the result (as planar WKB or a struct). I needed the struct export function because UNNEST didn't work and `::STRUCT(...)` was a mouthful to type.

```

# Test the box exporters
query I
SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
----
POLYGON ((5.9887 47.3025, 15.017 47.3025, 15.017 54.9831, 5.9887 54.9831, 5.9887 47.3025))

query I
SELECT s2_bounds_rect(s2_data_country('Fiji')).s2_box_wkb().s2_geogfromwkb().s2_format(4);
----
MULTIPOLYGON (((177.285 -18.288, 180 -18.288, 180 -16.0209, 177.285 -16.0209, 177.285 -18.288)), ((-180 -18.288, -179.7933 -18.288, -179.7933 -16.0209, -180 -16.0209, -180 -18.288)))

query I
SELECT s2_bounds_rect(s2_data_country('Germany')).s2_box_struct();
----
{'xmin': 5.988658, 'ymin': 47.30248799999997, 'xmax': 15.016996000000002, 'ymax': 54.983104000000026}

query I
SELECT s2_bounds_rect_agg(geog) FROM s2_data_countries();
----
{'xmin': -180.0, 'ymin': -90.0, 'xmax': 180.0, 'ymax': 83.64513000000002}
```