### PR TITLE
feat: Add validity checking functions

### DIFF
--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -39,6 +39,7 @@
 | [`s2_geogfromtext`](#s2_geogfromtext) | Returns the geography from a WKT string.|
 | [`s2_geogfromtext_novalidate`](#s2_geogfromtext_novalidate) | Returns the geography from a WKT string skipping validation.|
 | [`s2_geogfromwkb`](#s2_geogfromwkb) | Converts a WKB blob to a geography.|
+| [`s2_geogfromwkb_novalidate`](#s2_geogfromwkb_novalidate) | Returns the geography from a WKB blob skipping validation.|
 | [`s2_prepare`](#s2_prepare) | Prepares a geography for faster predicate and overlay operations.|
 | [`s2_data_city`](#s2_data_city) | Get an example city or country from [`s2_data_cities()`](#s2_data_cities)|
 | [`s2_data_country`](#s2_data_country) | Get an example city or country from [`s2_data_cities()`](#s2_data_cities)|
@@ -1180,6 +1181,33 @@ SELECT s2_geogfromwkb(s2_aswkb(s2_data_city('Toronto'))) as geog;
 --├────────────────────────────────┤
 --│ POINT (-79.4219667 43.7019257) │
 --└────────────────────────────────┘
+```
+
+### s2_geogfromwkb_novalidate
+
+Returns the geography from a WKB blob skipping validation.
+
+```sql
+GEOGRAPHY s2_geogfromwkb_novalidate(wkb BLOB)
+```
+
+#### Description
+
+This is useful to determine which of some set of geometries is not valid and
+why (or to help make them valid).
+
+#### Example
+
+```sql
+SELECT s2_geogfromwkb_novalidate(
+  s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)').s2_aswkb()
+);
+--┌───────────────────────────────────────────────────────────────────────────────────────────────┐
+--│ s2_geogfromwkb_novalidate(s2_aswkb(s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)'))) │
+--│                                           geography                                           │
+--├───────────────────────────────────────────────────────────────────────────────────────────────┤
+--│ LINESTRING (0 0, 0 0, 0.9999999999999997 1)                                                   │
+--└───────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### s2_prepare

--- a/src/s2_functions_io.cpp
+++ b/src/s2_functions_io.cpp
@@ -30,8 +30,39 @@ struct S2GeogFromText {
             variant.SetFunction(ExecuteFn);
           });
 
-          func.SetDescription("Returns the geography from a WKT string.");
-          // TODO: Example
+          func.SetDescription(R"(
+Returns the geography from a WKT string.
+
+This is an alias for the cast from VARCHAR to GEOGRAPHY. This
+function assumes spherical edges.
+)");
+          func.SetExample(R"(
+SELECT s2_geogfromtext('POINT (0 1)');
+----
+SELECT 'POINT (0 1)'::GEOGRAPHY;
+)");
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "conversion");
+        });
+
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_geogfromtext_novalidate", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("wkt", LogicalType::VARCHAR);
+            variant.SetReturnType(Types::GEOGRAPHY());
+            variant.SetFunction(ExecuteFnNovalidate);
+          });
+
+          func.SetDescription(R"(
+Returns the geography from a WKT string skipping validation.
+
+This is useful to determine which of some set of geometries is not valid and
+why.
+)");
+          func.SetExample(R"(
+SELECT s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)');
+)");
 
           func.SetTag("ext", "geography");
           func.SetTag("category", "conversion");
@@ -46,15 +77,24 @@ struct S2GeogFromText {
     Execute(args.data[0], result, args.size());
   }
 
+  static inline void ExecuteFnNovalidate(DataChunk& args, ExpressionState& state,
+                                         Vector& result) {
+    s2geography::geoarrow::ImportOptions options;
+    options.set_check(false);
+    Execute(args.data[0], result, args.size(), options);
+  }
+
   static inline bool ExecuteCast(Vector& source, Vector& result, idx_t count,
                                  CastParameters& parameters) {
     Execute(source, result, count);
     return true;
   }
 
-  static inline void Execute(Vector& source, Vector& result, idx_t count) {
+  static inline void Execute(Vector& source, Vector& result, idx_t count,
+                             const s2geography::geoarrow::ImportOptions& options =
+                                 s2geography::geoarrow::ImportOptions()) {
     GeographyEncoder encoder;
-    s2geography::WKTReader reader;
+    s2geography::WKTReader reader(options);
 
     UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](string_t wkt) {
       auto geog = reader.read_feature(wkt.GetData(), wkt.GetSize());

--- a/test/sql/accessors.test
+++ b/test/sql/accessors.test
@@ -16,6 +16,27 @@ SELECT s2_isempty('POINT (0 1)'::GEOGRAPHY)
 ----
 false
 
+# Validation
+query I
+SELECT s2_is_valid(s2_geogfromtext_novalidate('LINESTRING (0 0, 1 1)'));
+----
+true
+
+query I
+SELECT s2_is_valid(s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)'));
+----
+false
+
+query I
+SELECT s2_is_valid_reason(s2_geogfromtext_novalidate('LINESTRING (0 0, 1 1)')) = '';
+----
+true
+
+query I
+SELECT s2_is_valid_reason(s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)'));
+----
+Vertices 0 and 1 are identical
+
 # Area
 query I
 SELECT s2_area('POINT EMPTY'::GEOGRAPHY)

--- a/test/sql/functions_io.test
+++ b/test/sql/functions_io.test
@@ -11,6 +11,16 @@ SELECT ('POINT (-64 45)'::GEOGRAPHY).s2_format(6)
 ----
 POINT (-64 45)
 
+query I
+SELECT s2_geogfromtext('POINT (-64 45)').s2_format(6)
+----
+POINT (-64 45)
+
+query I
+SELECT s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)').s2_format(6)
+----
+LINESTRING (0 0, 0 0, 1 1)
+
 # WKB parse
 query I
 SELECT s2_geogfromwkb('\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x40\x00\x00\x00\x00\x00\x00\x24\x40').s2_format(6);

--- a/test/sql/functions_io.test
+++ b/test/sql/functions_io.test
@@ -33,6 +33,12 @@ SELECT ('POINT (-64 45)'::GEOGRAPHY).s2_aswkb().s2_geogfromwkb().s2_format(6)
 ----
 POINT (-64 45)
 
+# Read WKB skipping validation
+query I
+SELECT s2_geogfromwkb_novalidate(s2_geogfromtext_novalidate('LINESTRING (0 0, 0 0, 1 1)').s2_aswkb()).s2_format(6);
+----
+LINESTRING (0 0, 0 0, 1 1)
+
 # Prepare of small geographies doesn't trigger an index
 query I
 SELECT ('POINT (30 10)'::GEOGRAPHY).s2_prepare().s2_format(6);


### PR DESCRIPTION
Really we want to keep validity checking on pretty much always for unknown input, since the behaviour of invalid geographies is unpredictable in terms of containment or overlay. On the flip side, GEOS doesn't really validate anything (although sometimes has unpredictable results when these get put into some functions). In any case, when these errors do come up, it's helpful to be able to diagnose them.

`s2_geogfromtext/wkb_novalidate()` is a bit long...this could eventually be a named parameter like it is in R (`validate = false`).