### PR TITLE
feat: Wire up more functions from s2geography

### DIFF
--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -4,10 +4,12 @@
 | Function | Summary |
 | --- | --- |
 | [`s2_area`](#s2_area) | Calculate the area of the geography in square meters.|
+| [`s2_dimension`](#s2_dimension) | Calculate the highest dimension element present in the geography.|
 | [`s2_is_valid`](#s2_is_valid) | Returns true if the geography is valid.|
 | [`s2_is_valid_reason`](#s2_is_valid_reason) | Returns the error string for invalid geographies or the empty string ("") otherwise.|
 | [`s2_isempty`](#s2_isempty) | Returns true if the geography is empty.|
 | [`s2_length`](#s2_length) | Calculate the length of the geography in meters.|
+| [`s2_num_points`](#s2_num_points) | Extract the number of vertices in the geography.|
 | [`s2_perimeter`](#s2_perimeter) | Calculate the perimeter of the geography in meters.|
 | [`s2_x`](#s2_x) | Extract the longitude of a point geography.|
 | [`s2_y`](#s2_y) | Extract the latitude of a point geography.|
@@ -86,6 +88,65 @@ SELECT s2_area('POINT (0 0)'::GEOGRAPHY) AS area;
 --├────────┤
 --│    0.0 │
 --└────────┘
+```
+
+### s2_dimension
+
+Calculate the highest dimension element present in the geography.
+
+```sql
+INTEGER s2_dimension(geog GEOGRAPHY)
+```
+
+#### Description
+
+Points have a dimension of 0; linestrings have a dimension of 1; polygons have
+a dimension of 2. For geography collections, this will return the highest dimension
+value of any element in the collection (e.g., a collection containing a point and
+a polygon will return 2). An empty geography collection returns a value of -1.
+
+#### Example
+
+```sql
+SELECT s2_dimension('POINT (0 0)'::GEOGRAPHY);
+--┌────────────────────────────────────────────────┐
+--│ s2_dimension(CAST('POINT (0 0)' AS GEOGRAPHY)) │
+--│                     int32                      │
+--├────────────────────────────────────────────────┤
+--│                                              0 │
+--└────────────────────────────────────────────────┘
+
+SELECT s2_dimension('LINESTRING (0 0, 1 1)'::GEOGRAPHY);
+--┌──────────────────────────────────────────────────────────┐
+--│ s2_dimension(CAST('LINESTRING (0 0, 1 1)' AS GEOGRAPHY)) │
+--│                          int32                           │
+--├──────────────────────────────────────────────────────────┤
+--│                                                        1 │
+--└──────────────────────────────────────────────────────────┘
+
+SELECT s2_dimension(s2_data_country('Canada'));
+--┌─────────────────────────────────────────┐
+--│ s2_dimension(s2_data_country('Canada')) │
+--│                  int32                  │
+--├─────────────────────────────────────────┤
+--│                                       2 │
+--└─────────────────────────────────────────┘
+
+SELECT s2_dimension('GEOMETRYCOLLECTION EMPTY');
+--┌──────────────────────────────────────────┐
+--│ s2_dimension('GEOMETRYCOLLECTION EMPTY') │
+--│                  int32                   │
+--├──────────────────────────────────────────┤
+--│                                       -1 │
+--└──────────────────────────────────────────┘
+
+SELECT s2_dimension('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))'::GEOGRAPHY);
+--┌────────────────────────────────────────────────────────────────────────────────────────────┐
+--│ s2_dimension(CAST('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))' AS GEOGRAPHY)) │
+--│                                           int32                                            │
+--├────────────────────────────────────────────────────────────────────────────────────────────┤
+--│                                                                                          1 │
+--└────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### s2_is_valid
@@ -207,6 +268,34 @@ SELECT s2_length(s2_data_country('Canada')) AS length;
 --├────────┤
 --│    0.0 │
 --└────────┘
+```
+
+### s2_num_points
+
+Extract the number of vertices in the geography.
+
+```sql
+INTEGER s2_num_points(geog GEOGRAPHY)
+```
+
+#### Example
+
+```sql
+SELECT s2_num_points(s2_data_country('Fiji'));
+--┌────────────────────────────────────────┐
+--│ s2_num_points(s2_data_country('Fiji')) │
+--│                 int32                  │
+--├────────────────────────────────────────┤
+--│                                     17 │
+--└────────────────────────────────────────┘
+
+SELECT s2_num_points(s2_data_country('Canada'));
+--┌──────────────────────────────────────────┐
+--│ s2_num_points(s2_data_country('Canada')) │
+--│                  int32                   │
+--├──────────────────────────────────────────┤
+--│                                      761 │
+--└──────────────────────────────────────────┘
 ```
 
 ### s2_perimeter

--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -5,10 +5,12 @@
 | --- | --- |
 | [`s2_area`](#s2_area) | Calculate the area of the geography in square meters.|
 | [`s2_dimension`](#s2_dimension) | Calculate the highest dimension element present in the geography.|
+| [`s2_distance`](#s2_distance) | Calculate the shortest distance between two geographies.|
 | [`s2_is_valid`](#s2_is_valid) | Returns true if the geography is valid.|
 | [`s2_is_valid_reason`](#s2_is_valid_reason) | Returns the error string for invalid geographies or the empty string ("") otherwise.|
 | [`s2_isempty`](#s2_isempty) | Returns true if the geography is empty.|
 | [`s2_length`](#s2_length) | Calculate the length of the geography in meters.|
+| [`s2_max_distance`](#s2_max_distance) | Calculate the farthest distance between two geographies.|
 | [`s2_num_points`](#s2_num_points) | Extract the number of vertices in the geography.|
 | [`s2_perimeter`](#s2_perimeter) | Calculate the perimeter of the geography in meters.|
 | [`s2_x`](#s2_x) | Extract the longitude of a point geography.|
@@ -149,6 +151,29 @@ SELECT s2_dimension('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))'::G
 --└────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+### s2_distance
+
+Calculate the shortest distance between two geographies.
+
+```sql
+DOUBLE s2_distance(geog1 GEOGRAPHY, geog2 GEOGRAPHY)
+```
+
+#### Example
+
+```sql
+SELECT s2_distance(
+  s2_data_city('Vancouver'),
+  s2_data_country('United States of America')
+) AS distance;
+--┌───────────────────┐
+--│     distance      │
+--│      double       │
+--├───────────────────┤
+--│ 36920.79814219437 │
+--└───────────────────┘
+```
+
 ### s2_is_valid
 
 Returns true if the geography is valid.
@@ -268,6 +293,29 @@ SELECT s2_length(s2_data_country('Canada')) AS length;
 --├────────┤
 --│    0.0 │
 --└────────┘
+```
+
+### s2_max_distance
+
+Calculate the farthest distance between two geographies.
+
+```sql
+DOUBLE s2_max_distance(geog1 GEOGRAPHY, geog2 GEOGRAPHY)
+```
+
+#### Example
+
+```sql
+SELECT s2_max_distance(
+  s2_data_city('Vancouver'),
+  s2_data_country('United States of America')
+) AS distance;
+--┌───────────────────┐
+--│     distance      │
+--│      double       │
+--├───────────────────┤
+--│ 4543768.747999884 │
+--└───────────────────┘
 ```
 
 ### s2_num_points

--- a/src/s2_accessors.cpp
+++ b/src/s2_accessors.cpp
@@ -410,6 +410,69 @@ SELECT s2_y('POINT (-64 45)'::GEOGRAPHY);
   }
 };
 
+struct S2Dimension {
+  static void Register(DatabaseInstance& instance) {
+    FunctionBuilder::RegisterScalar(
+        instance, "s2_dimension", [](ScalarFunctionBuilder& func) {
+          func.AddVariant([](ScalarFunctionVariantBuilder& variant) {
+            variant.AddParameter("geog", Types::GEOGRAPHY());
+            variant.SetReturnType(LogicalType::INTEGER);
+            variant.SetFunction(ExecuteFn);
+          });
+
+          func.SetDescription(R"(
+Calculate the highest dimension element present in the geography.
+
+Points have a dimension of 0; linestrings have a dimension of 1; polygons have
+a dimension of 2. For geography collections, this will return the highest dimension
+value of any element in the collection (e.g., a collection containing a point and
+a polygon will return 2). An empty geography collection returns a value of -1.
+)");
+          func.SetExample(R"(
+SELECT s2_dimension('POINT (0 0)'::GEOGRAPHY);
+----
+SELECT s2_dimension('LINESTRING (0 0, 1 1)'::GEOGRAPHY);
+----
+SELECT s2_dimension(s2_data_country('Canada'));
+----
+SELECT s2_dimension('GEOMETRYCOLLECTION EMPTY');
+----
+SELECT s2_dimension('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))'::GEOGRAPHY);
+)");
+
+          func.SetTag("ext", "geography");
+          func.SetTag("category", "accessors");
+        });
+  }
+
+  static inline void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
+    Execute(args.data[0], result, args.size());
+  }
+
+  static void Execute(Vector& source, Vector& result, idx_t count) {
+    GeographyDecoder decoder;
+
+    UnaryExecutor::Execute<string_t, int32_t>(
+        source, result, count, [&](string_t geog_str) {
+          decoder.DecodeTag(geog_str);
+
+          switch (decoder.tag.kind) {
+            case s2geography::GeographyKind::CELL_CENTER:
+            case s2geography::GeographyKind::POINT:
+              return 0;
+            case s2geography::GeographyKind::POLYLINE:
+              return 1;
+            case s2geography::GeographyKind::POLYGON:
+              return 2;
+            default: {
+              auto geog = decoder.Decode(geog_str);
+              return s2geography::s2_dimension(*geog);
+            }
+          }
+        });
+  }
+};
+
 }  // namespace
 
 void RegisterS2GeographyAccessors(DatabaseInstance& instance) {
@@ -420,6 +483,7 @@ void RegisterS2GeographyAccessors(DatabaseInstance& instance) {
   S2Perimieter::Register(instance);
   S2Length::Register(instance);
   S2XY::Register(instance);
+  S2Dimension::Register(instance);
 }
 
 }  // namespace duckdb_s2

--- a/src/s2_binary_index_ops.cpp
+++ b/src/s2_binary_index_ops.cpp
@@ -24,8 +24,8 @@ using UniqueGeography = std::unique_ptr<s2geography::Geography>;
 // Handle the case where we've already computed the index on one or both
 // of the sides in advance
 template <typename ShapeIndexFilter>
-static auto DispatchShapeIndexFilter(UniqueGeography lhs, UniqueGeography rhs,
-                                     ShapeIndexFilter&& filter) {
+static auto DispaceShapeIndexOp(UniqueGeography lhs, UniqueGeography rhs,
+                                ShapeIndexFilter&& filter) {
   if (lhs->kind() == s2geography::GeographyKind::ENCODED_SHAPE_INDEX &&
       rhs->kind() == s2geography::GeographyKind::ENCODED_SHAPE_INDEX) {
     auto lhs_index =
@@ -243,7 +243,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispatchShapeIndexFilter(
+          return DispaceShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Intersects(lhs_index, rhs_index, options);
@@ -259,7 +259,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispatchShapeIndexFilter(
+          return DispaceShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Contains(lhs_index, rhs_index, options);
@@ -273,7 +273,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispatchShapeIndexFilter(
+          return DispaceShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Equals(lhs_index, rhs_index, options);
@@ -358,7 +358,7 @@ SELECT s2_union(
             return StringVector::AddStringOrBlob(result, encoder.Encode(*geog));
           }
 
-          auto geog = DispatchShapeIndexFilter(
+          auto geog = DispaceShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -401,7 +401,7 @@ SELECT s2_union(
             return StringVector::AddStringOrBlob(result, lhs_str);
           }
 
-          auto geog = DispatchShapeIndexFilter(
+          auto geog = DispaceShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -439,7 +439,7 @@ SELECT s2_union(
 
           // (No optimization for definitely disjoint binary union)
 
-          auto geog = DispatchShapeIndexFilter(
+          auto geog = DispaceShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -558,7 +558,7 @@ SELECT s2_max_distance(s2_data_city('Vancouver'), s2_data_country('United States
           auto geog1 = lhs_decoder.Decode(geog1_str);
           auto geog2 = rhs_decoder.Decode(geog2_str);
 
-          return DispatchShapeIndexFilter(std::move(geog1), std::move(geog2), op);
+          return DispaceShapeIndexOp(std::move(geog1), std::move(geog2), op);
         });
   }
 };

--- a/src/s2_binary_index_ops.cpp
+++ b/src/s2_binary_index_ops.cpp
@@ -24,8 +24,8 @@ using UniqueGeography = std::unique_ptr<s2geography::Geography>;
 // Handle the case where we've already computed the index on one or both
 // of the sides in advance
 template <typename ShapeIndexFilter>
-static auto DispaceShapeIndexOp(UniqueGeography lhs, UniqueGeography rhs,
-                                ShapeIndexFilter&& filter) {
+static auto DispatchShapeIndexOp(UniqueGeography lhs, UniqueGeography rhs,
+                                 ShapeIndexFilter&& filter) {
   if (lhs->kind() == s2geography::GeographyKind::ENCODED_SHAPE_INDEX &&
       rhs->kind() == s2geography::GeographyKind::ENCODED_SHAPE_INDEX) {
     auto lhs_index =
@@ -243,7 +243,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispaceShapeIndexOp(
+          return DispatchShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Intersects(lhs_index, rhs_index, options);
@@ -259,7 +259,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispaceShapeIndexOp(
+          return DispatchShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Contains(lhs_index, rhs_index, options);
@@ -273,7 +273,7 @@ SELECT s2_union(
 
     return ExecutePredicateFn(
         args, state, result, [&options](UniqueGeography lhs, UniqueGeography rhs) {
-          return DispaceShapeIndexOp(
+          return DispatchShapeIndexOp(
               std::move(lhs), std::move(rhs),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return S2BooleanOperation::Equals(lhs_index, rhs_index, options);
@@ -358,7 +358,7 @@ SELECT s2_union(
             return StringVector::AddStringOrBlob(result, encoder.Encode(*geog));
           }
 
-          auto geog = DispaceShapeIndexOp(
+          auto geog = DispatchShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -401,7 +401,7 @@ SELECT s2_union(
             return StringVector::AddStringOrBlob(result, lhs_str);
           }
 
-          auto geog = DispaceShapeIndexOp(
+          auto geog = DispatchShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -439,7 +439,7 @@ SELECT s2_union(
 
           // (No optimization for definitely disjoint binary union)
 
-          auto geog = DispaceShapeIndexOp(
+          auto geog = DispatchShapeIndexOp(
               lhs_decoder.Decode(lhs_str), rhs_decoder.Decode(rhs_str),
               [&options](const S2ShapeIndex& lhs_index, const S2ShapeIndex& rhs_index) {
                 return s2geography::s2_boolean_operation(
@@ -564,7 +564,7 @@ SELECT s2_max_distance(
           auto geog1 = lhs_decoder.Decode(geog1_str);
           auto geog2 = rhs_decoder.Decode(geog2_str);
 
-          return DispaceShapeIndexOp(std::move(geog1), std::move(geog2), op);
+          return DispatchShapeIndexOp(std::move(geog1), std::move(geog2), op);
         });
   }
 };

--- a/src/s2_binary_index_ops.cpp
+++ b/src/s2_binary_index_ops.cpp
@@ -479,7 +479,10 @@ struct S2Distance {
 Calculate the shortest distance between two geographies.
 )");
           func.SetExample(R"(
-SELECT s2_distance(s2_data_city('Vancouver'), s2_data_country('United States of America'));
+SELECT s2_distance(
+  s2_data_city('Vancouver'),
+  s2_data_country('United States of America')
+) AS distance;
 )");
 
           func.SetTag("ext", "geography");
@@ -499,7 +502,10 @@ SELECT s2_distance(s2_data_city('Vancouver'), s2_data_country('United States of 
 Calculate the farthest distance between two geographies.
 )");
           func.SetExample(R"(
-SELECT s2_max_distance(s2_data_city('Vancouver'), s2_data_country('United States of America'));
+SELECT s2_max_distance(
+  s2_data_city('Vancouver'),
+  s2_data_country('United States of America')
+) AS distance;
 )");
 
           func.SetTag("ext", "geography");

--- a/src/s2_binary_index_ops.cpp
+++ b/src/s2_binary_index_ops.cpp
@@ -516,13 +516,13 @@ SELECT s2_distance(s2_data_cities('Vancouver'), s2_data_cities('Toronto'));
 
           // Otherwise, decode and use s2_distance()
           auto geog1 = lhs_decoder.Decode(geog1_str);
-          auto geog2 = lhs_decoder.Decode(geog1_str);
+          auto geog2 = rhs_decoder.Decode(geog2_str);
 
           return DispatchShapeIndexFilter(
               std::move(geog1), std::move(geog2),
               [&](const S2ShapeIndex& lhs, const S2ShapeIndex& rhs) {
                 S2ClosestEdgeQuery query(&lhs);
-                S2MinDistanceShapeIndexTarget target(&rhs);
+                S2ClosestEdgeQuery::ShapeIndexTarget target(&rhs);
                 return query.FindClosestEdge(&target).distance().radians() *
                        S2Earth::RadiusMeters();
               });

--- a/test/sql/accessors.test
+++ b/test/sql/accessors.test
@@ -160,3 +160,24 @@ query I
 SELECT s2_dimension('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))'::GEOGRAPHY);
 ----
 1
+
+# Numpoints
+query I
+SELECT s2_num_points(s2_cellfromlonlat(-64, 45)::GEOGRAPHY);
+----
+1
+
+query I
+SELECT s2_num_points('POINT (-64 45)'::GEOGRAPHY);
+----
+1
+
+query I
+SELECT s2_num_points('LINESTRING (0 0, 1 1)'::GEOGRAPHY);
+----
+2
+
+query I
+SELECT s2_num_points('GEOMETRYCOLLECTION EMPTY');
+----
+0

--- a/test/sql/accessors.test
+++ b/test/sql/accessors.test
@@ -129,3 +129,34 @@ query I
 SELECT s2_y('POINT (-64 45)'::GEOGRAPHY::S2_CELL_CENTER).round()
 ----
 45
+
+# Dimension
+query I
+SELECT s2_dimension(s2_cellfromlonlat(-64, 45)::GEOGRAPHY);
+----
+0
+
+query I
+SELECT s2_dimension('POINT (-64 45)'::GEOGRAPHY);
+----
+0
+
+query I
+SELECT s2_dimension('LINESTRING (0 0, 1 1)'::GEOGRAPHY);
+----
+1
+
+query I
+SELECT s2_dimension(s2_data_country('Canada'));
+----
+2
+
+query I
+SELECT s2_dimension('GEOMETRYCOLLECTION EMPTY');
+----
+-1
+
+query I
+SELECT s2_dimension('GEOMETRYCOLLECTION (POINT (0 1), LINESTRING (0 0, 1 1))'::GEOGRAPHY);
+----
+1

--- a/test/sql/binary_index_ops.test
+++ b/test/sql/binary_index_ops.test
@@ -126,3 +126,29 @@ query I
 SELECT s2_union('POINT (-64 45)'::GEOGRAPHY, 'POINT (-64 46)'::GEOGRAPHY).s2_format(6);
 ----
 MULTIPOINT ((-64 45), (-64 46))
+
+# Distance
+
+# Normal (via S2ShapeIndex)
+query I
+SELECT s2_distance(s2_data_city('Vancouver')::S2_CELL_CENTER, s2_data_city('Toronto'));
+----
+3354018.3461295413
+
+# Points snapped to cell centers
+query I
+SELECT s2_distance(s2_data_city('Vancouver')::S2_CELL_CENTER, s2_data_city('Toronto')::S2_CELL_CENTER);
+----
+3354018.3501422736
+
+# Empty LHS
+query I
+SELECT s2_distance('POINT EMPTY'::GEOGRAPHY, s2_data_city('Toronto'));
+----
+inf
+
+# Empty RHS
+query I
+SELECT s2_distance(s2_data_city('Toronto'), 'POINT EMPTY'::GEOGRAPHY);
+----
+inf

--- a/test/sql/binary_index_ops.test
+++ b/test/sql/binary_index_ops.test
@@ -152,3 +152,35 @@ query I
 SELECT s2_distance(s2_data_city('Toronto'), 'POINT EMPTY'::GEOGRAPHY);
 ----
 inf
+
+# Max Distance
+
+# Normal (via S2ShapeIndex)
+query I
+SELECT s2_max_distance(s2_data_city('Vancouver')::S2_CELL_CENTER, s2_data_city('Toronto'));
+----
+3354018.3461295413
+
+# Points snapped to cell centers
+query I
+SELECT s2_max_distance(s2_data_city('Vancouver')::S2_CELL_CENTER, s2_data_city('Toronto')::S2_CELL_CENTER);
+----
+3354018.3501422736
+
+# Empty LHS
+query I
+SELECT s2_max_distance('POINT EMPTY'::GEOGRAPHY, s2_data_city('Toronto'));
+----
+inf
+
+# Empty RHS
+query I
+SELECT s2_max_distance(s2_data_city('Toronto'), 'POINT EMPTY'::GEOGRAPHY);
+----
+inf
+
+# Make sure distance and max_distance are different
+query I
+SELECT s2_max_distance(s2_data_city('Vancouver'), s2_data_country('Fiji')) > s2_distance(s2_data_city('Vancouver'), s2_data_country('Fiji'))
+----
+true


### PR DESCRIPTION
This PR adds:

- `s2_distance()`
- `s2_max_distance()`
- `s2_num_points()`
- `s2_dimension()`

...which fills out all of the "accessors" listed in the R documentation page.

Still to go:

- dwithin
- rebuild/make valid
- tessellation IO (i.e., planar = true)
- union aggregate
- buffer