### PR TITLE
feat: Add geoarrow IO and Python tests

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,8 +24,8 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.3
     with:
-      duckdb_version: v1.1.3
-      ci_tools_version: v1.1.3
+      duckdb_version: v1.2.0
+      ci_tools_version: v1.2.0
       extension_name: geography
 
   # Not currently working, and also we don't currently deploy anywhere

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,7 +22,7 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.0
     with:
       duckdb_version: v1.2.0
       ci_tools_version: v1.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testext
 test/python/__pycache__/
 .Rhistory
 .cache
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "cmake.sourceDirectory": "${workspaceFolder}/duckdb"
+    "cmake.sourceDirectory": "${workspaceFolder}/duckdb",
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "cmake.sourceDirectory": "${workspaceFolder}/duckdb",
-    "python.testing.pytestArgs": [
-        "test"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,8 @@ set(EXTENSION_SOURCES
     src/s2_binary_index_ops.cpp
     src/s2_data.cpp
     src/s2_accessors.cpp
-    src/s2_bounds.cpp)
+    src/s2_bounds.cpp
+    src/s2_geoarrow.cpp)
 
 # Workaround for difference between v1.1.3 and main with respect to
 # FunctionEntry fields

--- a/src/include/s2_functions_io.hpp
+++ b/src/include/s2_functions_io.hpp
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/main/database.hpp"
+
+#include "s2geography/geoarrow.h"
+
+namespace duckdb {
+namespace duckdb_s2 {
+void ImportWKBToGeography(Vector& source, Vector& result, idx_t count,
+                          const s2geography::geoarrow::ImportOptions& options =
+                              s2geography::geoarrow::ImportOptions());
+
+void ExportGeographyToWKB(Vector& source, Vector& result, idx_t count,
+                          const s2geography::geoarrow::ExportOptions& options =
+                              s2geography::geoarrow::ExportOptions());
+
+void RegisterS2GeographyFunctionsIO(DatabaseInstance& instance);
+}  // namespace duckdb_s2
+}  // namespace duckdb

--- a/src/include/s2_geography_ops.hpp
+++ b/src/include/s2_geography_ops.hpp
@@ -2,20 +2,23 @@
 
 #include "duckdb/main/database.hpp"
 
+#include "s2_functions_io.hpp"
+
 namespace duckdb {
 
 namespace duckdb_s2 {
 
-void RegisterS2GeographyFunctionsIO(DatabaseInstance& instance);
 void RegisterS2GeographyPredicates(DatabaseInstance& instance);
 void RegisterS2GeographyAccessors(DatabaseInstance& instance);
 void RegisterS2GeographyBounds(DatabaseInstance& instance);
+void RegisterGeoArrowExtensions(DatabaseInstance& instance);
 
 inline void RegisterS2GeographyOps(DatabaseInstance& instance) {
   RegisterS2GeographyFunctionsIO(instance);
   RegisterS2GeographyPredicates(instance);
   RegisterS2GeographyAccessors(instance);
   RegisterS2GeographyBounds(instance);
+  RegisterGeoArrowExtensions(instance);
 }
 
 }  // namespace duckdb_s2

--- a/src/s2_bounds.cpp
+++ b/src/s2_bounds.cpp
@@ -4,11 +4,8 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_util.hpp"
 
-#include "s2/s2earth.h"
-#include "s2/s2region_coverer.h"
-#include "s2geography/accessors.h"
-
 #include "s2/s2cell_union.h"
+#include "s2/s2region_coverer.h"
 #include "s2_geography_serde.hpp"
 #include "s2_types.hpp"
 

--- a/src/s2_dependencies.cpp
+++ b/src/s2_dependencies.cpp
@@ -1,5 +1,3 @@
-#include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension_util.hpp"
 

--- a/src/s2_functions_io.cpp
+++ b/src/s2_functions_io.cpp
@@ -311,7 +311,9 @@ SELECT s2_aswkb(s2_data_city('Toronto')) as wkb;
     Execute(args.data[0], result, args.size());
   }
 
-  static inline void Execute(Vector& source, Vector& result, idx_t count) {
+  static inline void Execute(Vector& source, Vector& result, idx_t count,
+                             const s2geography::geoarrow::ExportOptions& options =
+                                 s2geography::geoarrow::ExportOptions()) {
     GeographyDecoder decoder;
     s2geography::WKBWriter writer;
 
@@ -388,6 +390,16 @@ LIMIT 5;
         });
   }
 };
+
+void ImportWKBToGeography(Vector& source, Vector& result, idx_t count,
+                          const s2geography::geoarrow::ImportOptions& options) {
+  S2GeogFromWKB::Execute(source, result, count, options);
+}
+
+void ExportGeographyToWKB(Vector& source, Vector& result, idx_t count,
+                          const s2geography::geoarrow::ExportOptions& options) {
+  S2AsWKB::Execute(source, result, count, options);
+}
 
 void RegisterS2GeographyFunctionsIO(DatabaseInstance& instance) {
   S2GeogFromText::Register(instance);

--- a/src/s2_geoarrow.cpp
+++ b/src/s2_geoarrow.cpp
@@ -1,0 +1,141 @@
+#include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/schema_metadata.hpp"
+#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_util.hpp"
+
+#include "geoarrow/geoarrow.hpp"
+
+#include "s2_functions_io.hpp"
+#include "s2_types.hpp"
+
+namespace duckdb {
+
+namespace duckdb_s2 {
+
+namespace {
+
+struct GeoArrowWKB {
+  static unique_ptr<ArrowType> GetType(const ArrowSchema& schema,
+                                       const ArrowSchemaMetadata& schema_metadata) {
+    // Validate extension metadata. This metadata also contains a CRS, which we drop
+    // because the GEOMETRY type does not implement a CRS at the type level.
+    string extension_metadata =
+        schema_metadata.GetOption(ArrowSchemaMetadata::ARROW_METADATA_KEY);
+    if (!extension_metadata.empty()) {
+      throw NotImplementedException(
+          "Can't import planar edges as GEOGRAPHY (metadata empty)");
+    }
+
+    auto data_type =
+        geoarrow::GeometryDataType::Make(GEOARROW_TYPE_WKB, extension_metadata);
+    if (data_type.edge_type() != GEOARROW_EDGE_TYPE_SPHERICAL) {
+      throw NotImplementedException("Can't import non-spherical edges as GEOGRAPHY");
+    }
+
+    const auto format = string(schema.format);
+    if (format == "z") {
+      return make_uniq<ArrowType>(
+          Types::GEOGRAPHY(), make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+    } else if (format == "Z") {
+      return make_uniq<ArrowType>(
+          Types::GEOGRAPHY(),
+          make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
+    } else if (format == "vz") {
+      return make_uniq<ArrowType>(
+          Types::GEOGRAPHY(), make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
+    } else {
+      throw InvalidInputException(
+          "Arrow storage type \"%s\" not supported for geoarrow.wkb", format.c_str());
+    }
+  }
+
+  static void PopulateSchema(DuckDBArrowSchemaHolder& root_holder, ArrowSchema& schema,
+                             const LogicalType& type, ClientContext& context,
+                             const ArrowTypeExtension& extension) {
+    auto data_type =
+        geoarrow::Wkb().WithEdgeType(GEOARROW_EDGE_TYPE_SPHERICAL).WithCrsLonLat();
+
+    ArrowSchemaMetadata schema_metadata;
+    schema_metadata.AddOption(ArrowSchemaMetadata::ARROW_EXTENSION_NAME,
+                              data_type.extension_name());
+    schema_metadata.AddOption(ArrowSchemaMetadata::ARROW_METADATA_KEY,
+                              data_type.extension_metadata());
+    root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
+    schema.metadata = root_holder.metadata_info.back().get();
+
+    const auto options = context.GetClientProperties();
+    if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
+      schema.format = "Z";
+    } else {
+      schema.format = "z";
+    }
+  }
+
+  static void ArrowToDuck(ClientContext& context, Vector& source, Vector& result,
+                          idx_t count) {
+    s2geography::geoarrow::ImportOptions options;
+    options.set_check(false);
+    options.set_oriented(true);
+    ImportWKBToGeography(source, result, count);
+  }
+
+  static void DuckToArrow(ClientContext& context, Vector& source, Vector& result,
+                          idx_t count) {
+    ExportGeographyToWKB(source, result, count);
+  }
+};
+
+void RegisterArrowExtensions(DBConfig& config) {
+  config.RegisterArrowExtension(
+      {"geoarrow.wkb", GeoArrowWKB::PopulateSchema, GeoArrowWKB::GetType,
+       make_shared_ptr<ArrowTypeExtensionData>(Types::GEOGRAPHY(), LogicalType::BLOB,
+                                               GeoArrowWKB::ArrowToDuck,
+                                               GeoArrowWKB::DuckToArrow)});
+}
+
+class GeoArrowRegisterFunctionData final : public TableFunctionData {
+ public:
+  GeoArrowRegisterFunctionData() : finished(false) {}
+  bool finished{false};
+};
+
+unique_ptr<FunctionData> GeoArrowRegisterBind(ClientContext& context,
+                                              TableFunctionBindInput& input,
+                                              vector<LogicalType>& return_types,
+                                              vector<string>& names) {
+  names.push_back("registered");
+  return_types.push_back(LogicalType::BOOLEAN);
+  return make_uniq<GeoArrowRegisterFunctionData>();
+}
+
+void GeoArrowRegisterScan(ClientContext& context, TableFunctionInput& data_p,
+                          DataChunk& output) {
+  auto& data = data_p.bind_data->CastNoConst<GeoArrowRegisterFunctionData>();
+  if (data.finished) {
+    return;
+  }
+
+  DBConfig& config = DatabaseInstance::GetDatabase(context).config;
+  if (config.HasArrowExtension(Types::GEOGRAPHY())) {
+    output.SetValue(0, 0, false);
+  } else {
+    RegisterArrowExtensions(config);
+    output.SetValue(0, 0, true);
+  }
+
+  output.SetCardinality(1);
+  data.finished = true;
+}
+}  // namespace
+
+void RegisterGeoArrowExtensions(DatabaseInstance& instance) {
+  TableFunction register_func("s2_register_geoarrow_extensions", {}, GeoArrowRegisterScan,
+                              GeoArrowRegisterBind);
+  ExtensionUtil::RegisterFunction(instance, register_func);
+}
+
+}  // namespace duckdb_s2
+
+}  // namespace duckdb

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,40 @@
+import glob
+from pathlib import Path
+
+import pytest
+import duckdb
+import warnings
+
+
+HERE = Path(__file__).parent
+
+
+def _install_dev_and_connect():
+    con = duckdb.connect(config={"allow_unsigned_extensions": True})
+
+    possible_builds = glob.glob(
+        "build/**/geography/geography.duckdb_extension",
+        recursive=True,
+        root_dir=HERE.parent.parent,
+    )
+    if possible_builds:
+        con.install_extension(possible_builds[0], force_install=True)
+    else:
+        warnings.warn(
+            "Can't find build directory for geography.duckdb_extension; skipping INSTALL"
+        )
+
+    con.load_extension("geography")
+    return con
+
+
+@pytest.fixture()
+def geoarrow_con():
+    con = _install_dev_and_connect()
+    con.sql("""CALL s2_register_geoarrow_extensions()""")
+    return con
+
+
+@pytest.fixture()
+def con():
+    return _install_dev_and_connect()

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,4 +1,5 @@
 duckdb
 pytest
 spherely
-geoarrow-pyarrow
+numpy
+pyarrow

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,0 +1,4 @@
+duckdb
+pytest
+spherely
+geoarrow-pyarrow

--- a/test/python/test_geoarrow.py
+++ b/test/python/test_geoarrow.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+import json
+
+import pyarrow as pa
+import pytest
+
+import duckdb
+
+HERE = Path(__file__).parent
+
+
+def test_export_without_register(con):
+    tab = con.sql("""SELECT s2_geogfromtext('POINT (0 1)') as geom;""").to_arrow_table()
+    assert tab.schema.field("geom").metadata is None
+
+
+def test_basic_export(geoarrow_con):
+    tab = geoarrow_con.sql(
+        """SELECT s2_geogfromtext('POINT (0 1)') as geom;"""
+    ).to_arrow_table()
+    metadata = tab.schema.field("geom").metadata
+    assert metadata[b"ARROW:extension:name"] == b"geoarrow.wkb"
+    params = json.loads(metadata[b"ARROW:extension:metadata"])
+    assert params["edges"] == "spherical"
+    assert params["crs"] == "OGC:CRS84"
+
+
+def test_basic_import(geoarrow_con):
+    field = pa.field(
+        "geometry",
+        pa.binary(),
+        metadata={
+            "ARROW:extension:name": "geoarrow.wkb",
+            "ARROW:extension:metadata": '{"edges": "spherical"}',
+        },
+    )
+    point_wkb = (
+        b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00$@\x00\x00\x00\x00\x00\x004@"
+    )
+    schema = pa.schema([field])
+    geo_table = pa.table(
+        [pa.array([point_wkb])],
+        schema=schema,
+    )
+
+    tab = geoarrow_con.sql(
+        """SELECT s2_astext(geometry) as wkt FROM geo_table;"""
+    ).to_arrow_table()
+    assert tab["wkt"].to_pylist() == ["POINT (10 20)"]
+
+
+def test_reject_planar_edges(geoarrow_con):
+    # Empty metadata
+    bad_metadata = {
+        "ARROW:extension:name": "geoarrow.wkb",
+        "ARROW:extension:metadata": "",
+    }
+    field = pa.field("geometry", pa.binary(), metadata=bad_metadata)
+    geo_table = pa.table([pa.array([], pa.binary())], schema=pa.schema([field]))
+    with pytest.raises(
+        duckdb.NotImplementedException,
+        match="Can't import non-spherical edges as GEOGRAPHY",
+    ):
+        geoarrow_con.sql("""SELECT * from geo_table""")
+
+
+def test_roundtrip_segments(geoarrow_con):
+    countries_file = HERE.parent.parent / "data" / "countries.tsv"
+    geo_table = geoarrow_con.sql(
+        f"""SELECT s2_geogfromtext(geog) as geog1 FROM '{countries_file}'"""
+    ).to_arrow_table()
+    geo_table2 = geoarrow_con.sql(
+        """SELECT geog1 as geog2 FROM geo_table"""
+    ).to_arrow_table()
+
+    table_both = pa.table(
+        [geo_table["geog1"], geo_table2["geog2"]],
+        schema=pa.schema([geo_table.schema.field(0), geo_table2.schema.field(0)]),
+    )
+    areas_equal = geoarrow_con.sql(
+        """SELECT sum(abs(s2_area(geog1) - s2_area(geog2)) < 0.1)::BIGINT AS sum_eq FROM table_both"""
+    ).to_arrow_table()
+    assert areas_equal == pa.table({"sum_eq": [len(table_both)]})

--- a/test/sql/geoarrow.test
+++ b/test/sql/geoarrow.test
@@ -1,0 +1,6 @@
+require geography
+
+query I
+SELECT * FROM s2_register_geoarrow_extensions();
+----
+true


### PR DESCRIPTION
It works!

```python
import duckdb
import geoarrow.pyarrow as ga
import spherely

con = duckdb.connect(config={"allow_unsigned_extensions": True})
con.load_extension("build/extension/geography/geography.duckdb_extension")
con.sql("""CALL s2_register_geoarrow_extensions()""")

#> ┌────────────┐
#> │ registered │
#> │  boolean   │
#> ├────────────┤
#> │ true       │
#> └────────────┘

tab = con.sql("""SELECT * FROM s2_data_countries() WHERE continent = 'Europe'""").to_arrow_table()
geogs = spherely.from_geoarrow(tab["geog"].chunk(0))
spherely.area(geogs[:5])
#> array([2.96555845e+10, 8.48241176e+10, 3.00196248e+10, 1.10029958e+11,
#>        5.05023890e+10])
```