### PR TITLE
Force C++17 for the whole build to fix the arm64 plan_serializer link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,14 @@ include(FetchContent)
 # Set extension name here
 set(TARGET_NAME geography)
 
-# Required for S2
-set(CMAKE_CXX_STANDARD 17)
+# Required for S2. CACHE ... FORCE so DuckDB's own build picks it up too:
+# DuckDB configures C++11, where the static constexpr class-type member
+# duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS is not implicitly inline, and
+# GCC 14 on aarch64 then rejects the duplicate when linking tools/plan_serializer
+# (duckdb/duckdb#22097). That tool arrived in DuckDB v1.5.2, which is exactly
+# when this extension stopped building.
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to enforce" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # DuckDB's extension distribution supports vcpkg. As such, dependencies can be
 # added in ./vcpkg.json and then used in cmake with find_package. Feel free to


### PR DESCRIPTION
This is a clauded attempt to help out getting 1.5.5 duckdb, as it lets us fix an issue we're having, and we depend on geography for our s2 add / partition commands. This is claude's PR body:

> This extension hasn't published to community-extensions since DuckDB v1.5.1 — v1.5.2 through v1.5.5 return 404 on every platform, and the arm64 job on `main` is red. `geography.duckdb_extension` itself links fine (step 668/686); the build then dies at 674/686 on `tools/plan_serializer` with `multiple definition of duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS` under gcc-toolset-14/aarch64. That's duckdb/duckdb#22097 — DuckDB configures C++11, where that `static constexpr` member isn't implicitly inline. `plan_serializer` was added in DuckDB v1.5.2, exactly where publishing stopped.

> `set(CMAKE_CXX_STANDARD 17)` here is directory-scoped, so DuckDB's own targets stay at C++11. Adding `CACHE ... FORCE` applies it across the whole build. Same fix as DataZooDE/anofox-forecast#220 and duckdb/community-extensions#2170, both publishing at v1.5.5 now.

> Relevant to #33: community-extensions CI already failed at the currently-listed ref ([run 27813918721](https://github.com/duckdb/community-extensions/actions/runs/27813918721)), so bumping the listing alone won't republish it — this needs to land first. I can't test arm64 Linux locally; your CI matrix is the real check.

Feel free to redo / close, but it seemed decent.
