### PR TITLE
Apply cmake-format to CMakeLists.txt to fix pre-commit on main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,15 @@ include(FetchContent)
 # Set extension name here
 set(TARGET_NAME geography)
 
-# Required for S2. CACHE ... FORCE so DuckDB's own build picks it up too:
-# DuckDB configures C++11, where the static constexpr class-type member
+# Required for S2. CACHE ... FORCE so DuckDB's own build picks it up too: DuckDB
+# configures C++11, where the static constexpr class-type member
 # duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS is not implicitly inline, and
-# GCC 14 on aarch64 then rejects the duplicate when linking tools/plan_serializer
-# (duckdb/duckdb#22097). That tool arrived in DuckDB v1.5.2, which is exactly
-# when this extension stopped building.
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to enforce" FORCE)
+# GCC 14 on aarch64 then rejects the duplicate when linking
+# tools/plan_serializer (duckdb/duckdb#22097). That tool arrived in DuckDB
+# v1.5.2, which is exactly when this extension stopped building.
+set(CMAKE_CXX_STANDARD
+    17
+    CACHE STRING "C++ standard to enforce" FORCE)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # DuckDB's extension distribution supports vcpkg. As such, dependencies can be


### PR DESCRIPTION
Another clauded drive-by, same motivation as #34 — we depend on `geography` for gpio's S2 commands. Claude's body:

> `main` is red on the `pre-commit` job ([run 33290956541](https://github.com/paleolimbot/duckdb-geography/actions/runs/33290956541/job/99202374671)) — `cmake-format` wants to reflow the comment and `set()` call that #34 added to `CMakeLists.txt`. Purely cosmetic; every build job on `05dcc8f` is green, including the `linux_arm64` one #34 fixed.

> This commit is just `pre-commit run cmake-format --all-files` applied verbatim, no hand edits. The `set(CMAKE_CXX_STANDARD 17 CACHE STRING ... FORCE)` split across four lines is cmake-format's own preference for a multi-argument `set()`, not mine.

Feel free to redo / close.
